### PR TITLE
fix: 모바일 뷰 가로, 세로 스크롤 바 이슈 해결

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,14 @@ body {
   min-width: 320px;
   min-height: 100vh;
 }
+
+/* 모바일 뷰 가로 스크롤 해결*/
+html, body {
+  overflow-x: auto;
+  width: 100%;
+}
+
+/* 모바일 뷰 세로 스크롤 해결*/
+html{
+  height: max-content;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
-const HomePage = () => {
+export const HomePage = () => {
   return (
-    <>
+    <div>
       <div>
         HomePage Lorem ipsum dolor sit amet consectetur, adipisicing elit. Laborum animi aut dolore,
         facilis eius quod placeat. Vitae, illum! Aliquid aperiam facilis, labore numquam reiciendis
@@ -76,8 +76,9 @@ const HomePage = () => {
         facilis nulla recusandae cumque explicabo. Provident eligendi pariatur quia incidunt debitis
         dolores nisi, et assumenda distinctio amet!
       </div>
-    </>
+      <div style={{ width: 320, backgroundColor: 'red', overflowWrap: 'break-word' }}>
+        320320320320320320320320320320320320320320320320320320320320320320320320320
+      </div>
+    </div>
   );
 };
-
-export default HomePage;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -4,7 +4,7 @@ import { MainLayout } from '@/layouts/MainLayout';
 import { PlainLayout } from '@/layouts/PlainLayout';
 import AlarmPage from '@/pages/AlarmPage';
 import CalendarPage from '@/pages/CalendarPage';
-import HomePage from '@/pages/HomePage';
+import { HomePage } from '@/pages/HomePage';
 import InfoPage from '@/pages/InfoPage';
 import LoginPage from '@/pages/LoginPage';
 import MyPage from '@/pages/MyPage';


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

문제 현상
- 세로 스크롤바가 BottomNav에 가려지는 현상.
- 320px보다 작아질 때 발생하는 가로 스크롤 바로 인해, 또 다른 세로 스크롤 바가 생기는 현상.
- 가로 스크롤바가 지정한 320px이 아닌 337px부터 생기는 현상.

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #9 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- index.css에 가로 스크롤 및 세로 길이 조절하는 css 추가

overflow-x: auto; -> 가로 스크롤 해결
height: max-content; -> 세로 스크롤 해결

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [ ] 320px까지 가로 스크롤 없음.
- [ ] 319px부터 가로 스크롤 생성.
- [ ] 세로 스크롤은 BottomNav에 가려지지 않음.

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
HomePage named export 방식으로 수정했습니다. 여러 PR 머지 시 고려하세요!