### PR TITLE
chore: 카카오 로그인 배포 환경 대응 설정 (KB3-94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-.env
+.env.*
 node_modules
 dist
 dist-ssr

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -2,52 +2,76 @@ import axios from 'axios';
 
 import { axiosInstance } from './axiosInstance';
 
+const isDev = import.meta.env.MODE === 'development';
+
+/**
+ * 카카오 로그인 요청
+ * - dev: 응답에서 accessToken, refreshToken 반환
+ * - prod: 쿠키(HttpOnly) 기반 자동 저장, 별도 응답 처리 없음
+ */
 export const kakaoLogin = async (code: string) => {
+  const endpoint = isDev ? 'auth/kakao/login/dev' : 'auth/kakao/login';
+
   try {
-    await axios.get(`auth/kakao/login`, {
+    const response = await axios.get(endpoint, {
       params: { code },
     });
+
+    // 개발환경일 경우 accessToken, refreshToken 반환
+    if (isDev) {
+      return {
+        accessToken: response.data.content.accessToken,
+        refreshToken: response.data.content.refreshToken,
+      };
+    }
+
+    // 배포 환경은 쿠키 기반 저장 → 응답 별도 처리 없음
+    return null;
   } catch (error) {
-    console.error('kakao Login failed:', error);
+    console.error('kakao login failed:', error);
     throw error;
   }
 };
 
-export const kakaoLoginDev = async (code: string) => {
-  try {
-    const response = await axios.get(`auth/kakao/login/dev`, {
-      params: { code },
-    });
-    return response;
-  } catch (error) {
-    console.error('kakao Login failed:', error);
-    throw error;
-  }
-};
-
+/**
+ * 카카오 로그아웃 요청
+ * - dev: refreshToken body로 전달
+ * - prod: 쿠키 기반 로그아웃
+ */
 export const kakaoLogout = async () => {
+  const endpoint = isDev ? 'auth/kakao/logout/dev' : 'auth/kakao/logout';
+
   try {
-    await axiosInstance.post('auth/kakao/logout', '');
+    const body = isDev ? { refreshToken: localStorage.getItem('refreshToken') } : undefined; // prod는 쿠키 기반이라 body 비움
+
+    await axiosInstance.post(endpoint, body);
   } catch (error) {
-    console.error('logout failed: ', error);
+    console.error('kakao logout failed:', error);
     throw error;
   }
 };
 
-export const kakaoLogoutDev = async () => {
-  try {
-    await axiosInstance.post('auth/kakao/logout/dev', '');
-  } catch (error) {
-    console.error('logout failed: ', error);
-    throw error;
-  }
-};
-
+/**
+ * 카카오 회원탈퇴 (dev/prod 공통)
+ */
 export const kakaoWithdraw = async () => {
   try {
     await axiosInstance.post('auth/kakao/withdraw');
   } catch (error) {
     console.error('user delete failed: ', error);
+    throw error;
+  }
+};
+
+/**
+ * Access Token을 쿠키로 재설정 요청 (서버가 쿠키로만 발급하는 경우에 사용)
+ * - 주로 로그인 직후, 쿠키 기반 토큰을 새로 심기 위해 사용
+ */
+export const getAccessTokenFromCookie = async () => {
+  try {
+    await axiosInstance.get('/auth/accesscookie');
+  } catch (error) {
+    console.error('get access cookie failed:', error);
     throw error;
   }
 };

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,5 +1,7 @@
 import axios, { type InternalAxiosRequestConfig } from 'axios';
 
+const isDev = import.meta.env.MODE === 'development';
+
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL,
   withCredentials: true,
@@ -7,9 +9,12 @@ export const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    const accessToken = localStorage.getItem('accessToken');
-    if (accessToken) {
-      config.headers['Authorization'] = `Bearer ${accessToken}`;
+    // 개발환경일 때만 accessToken 헤더 추가
+    if (isDev) {
+      const accessToken = localStorage.getItem('accessToken');
+      if (accessToken) {
+        config.headers['Authorization'] = `Bearer ${accessToken}`;
+      }
     }
     return config;
   },
@@ -19,7 +24,50 @@ axiosInstance.interceptors.request.use(
   }
 );
 
-// refreshToken으로 accessToken 발급받는 로직은 배포 후에 추가 예정
-axiosInstance.interceptors.response.use();
+axiosInstance.interceptors.response.use(
+  response => response,
+  async error => {
+    const originalRequest = error.config;
 
-export const getRefreshToken = async () => {};
+    if (error.response?.status === 401) {
+      try {
+        const newAccessToken = await refreshAccessToken();
+
+        if (isDev && newAccessToken) {
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+        }
+
+        return axiosInstance(originalRequest); // 요청 재시도
+      } catch (e) {
+        console.error('토큰 갱신 실패:', e);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+/**
+ * Access Token 재발급 요청 (401 대응용)
+ * - dev: refreshToken을 body로 포함
+ * - prod: 쿠키에서 자동 전달 (HttpOnly)
+ */
+const refreshAccessToken = async () => {
+  try {
+    const body = isDev ? { refreshToken: localStorage.getItem('refreshToken') } : undefined;
+
+    const response = await axiosInstance.post('/auth/refresh', body);
+
+    if (isDev) {
+      const newAccessToken = response.data.content.accessToken;
+      localStorage.setItem('accessToken', newAccessToken);
+      return newAccessToken;
+    }
+
+    // prod: 서버가 쿠키로 재설정 → 별도 처리 없음
+    return null;
+  } catch (error) {
+    console.error('refresh token failed:', error);
+    throw error;
+  }
+};

--- a/src/pages/AuthRedirectPage.tsx
+++ b/src/pages/AuthRedirectPage.tsx
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
-import { kakaoLoginDev } from '@/apis/auth';
+import { getAccessTokenFromCookie, kakaoLogin } from '@/apis/auth';
+
+const isDev = import.meta.env.MODE === 'development';
 
 export const AuthRedirectPage = () => {
   const navigate = useNavigate();
@@ -13,15 +15,18 @@ export const AuthRedirectPage = () => {
 
     const getToken = async () => {
       try {
-        const response = await kakaoLoginDev(code);
+        const result = await kakaoLogin(code);
 
-        const accessToken = response.data.content.accessToken;
-        const refreshToken = response.data.content.refreshToken;
+        if (isDev && result) {
+          localStorage.setItem('accessToken', result.accessToken);
+          localStorage.setItem('refreshToken', result.refreshToken);
+        }
 
-        localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
+        if (!isDev) {
+          await getAccessTokenFromCookie(); // ✅ prod 환경에서 AT 쿠키 설정
+        }
 
-        navigate('/');
+        navigate('/signup/pet'); // TODO: 추후 반려동물 유무에 따라 navigate 경로 수정 필요.
       } catch (err) {
         console.error('로그인 실패', err);
         navigate('/login');

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { Backpack } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { BriefCard } from '@/features/home/BriefCard';
@@ -14,10 +15,11 @@ export const HomePage = () => {
   const petId = 2; // 실제로는 전역 상태나 route param에서 가져오겠죠
   const { schedules, remarks, loading, error } = useBriefCardData(petId);
 
+  const navigate = useNavigate();
   return (
     <Container>
       <Header>
-        <StyledLogo />
+        <StyledLogo onClick={() => navigate('/signup/pet')} />
         <Backpack size={24} stroke="#444" />
       </Header>
 

--- a/src/pages/SignupPetRegisterPage.tsx
+++ b/src/pages/SignupPetRegisterPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { PetRegisterForm } from '@/components/PetRegisterForm';
@@ -13,6 +14,7 @@ export const SignupPetRegisterPage = () => {
     birthDate: new Date(),
   });
   const [isPetFormValid, setIsPetFormValid] = useState(false);
+  const navigate = useNavigate();
 
   return (
     <Container>
@@ -20,7 +22,9 @@ export const SignupPetRegisterPage = () => {
 
       <PetRegisterForm form={form} setForm={setForm} onFormValidChange={setIsPetFormValid} />
 
-      <NextButton disabled={!isPetFormValid}>다음</NextButton>
+      <NextButton onClick={() => navigate('/slot')} disabled={!isPetFormValid}>
+        다음
+      </NextButton>
     </Container>
   );
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -2,8 +2,8 @@ import { createBrowserRouter } from 'react-router-dom';
 
 import { MainLayout } from '@/layouts/MainLayout';
 import { PlainLayout } from '@/layouts/PlainLayout';
-import { AuthRedirectPage } from '@/pages/AuthRedirectPage';
 import { AlarmPage } from '@/pages/AlarmPage';
+import { AuthRedirectPage } from '@/pages/AuthRedirectPage';
 import { CalendarPage } from '@/pages/CalendarPage';
 import { HomePage } from '@/pages/HomePage';
 import InfoPage from '@/pages/InfoPage';


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 개발/배포 환경을 구분하여 카카오 로그인 및 토큰 관리 방식 분리 적용

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #41 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- 개발 환경에서는 `localStorage`를 활용한 accessToken / refreshToken 저장
- 배포 환경에서는 HttpOnly 쿠키 기반으로 accessToken / refreshToken 관리
- `/auth/refresh` 요청 시, 환경에 따라 토큰 재발급 방식 분기 처리
  - dev: body에 refreshToken 포함 → accessToken 재발급 후 로컬스토리지에 저장
  - prod: 서버에서 쿠키 갱신 → 클라이언트는 응답 본문 처리 없이 요청만 수행
- Axios 인스턴스 request/response 인터셉터 내 로직 환경별 분기 적용
- 로그인 직후 `/auth/accesscookie` 요청을 보내 accessToken을 서버에서 쿠키로 설정하도록 처리.

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [ ] 개발 환경에서 로그인/재로그인/로그아웃 흐름 정상 동작
- [ ] 배포 환경에서 쿠키 기반 로그인/자동 인증 갱신 흐름 정상 동작
- [ ] AT 만료 후 자동 갱신 후 재요청 정상 처리됨

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
Git-Flow 전략에 따라 develop으로 머지된 후, release 브랜치로 분기해서 배포환경 기준 테스트 작업 진행하려 합니다!