### PR TITLE
hotfix: 카카오 인증 후 리디렉션 시 쿠키 설정 API 호출 처리 (KB3-95)

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -64,28 +64,9 @@ export const kakaoWithdraw = async () => {
 };
 
 /**
- * Access Token을 쿠키로 재설정 요청 (서버가 쿠키로만 발급하는 경우에 사용)
- * - 주로 로그인 직후, 쿠키 기반 토큰을 새로 심기 위해 사용
- */
-export const getAccessTokenFromCookie = async () => {
-  try {
-    await axiosInstance.get('/auth/accesscookie');
-  } catch (error) {
-    console.error('get access cookie failed:', error);
-    throw error;
-  }
-};
-
-/**
  * 서버에 쿠키 기반 인증 상태 확인 요청
- * @returns 인증 성공 시 true, 실패 시 false
  */
 export const verifyAuth = async (): Promise<boolean> => {
-  try {
-    await axios.get('/auth/verify'); // 200 OK 시 인증됨
-    return true;
-  } catch (err) {
-    console.log('verify auth failed:', err);
-    return false;
-  }
+  const res = await axiosInstance.get('/auth/verify'); // 서버에서 쿠키 기반 검증
+  return res.data.isAuthenticated; // 서버에서 { isAuthenticated: true } 응답 가정
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
-import { axiosInstance } from './axiosInstance';
+import { IS_DEV } from '@/constants/env';
 
-const isDev = import.meta.env.MODE === 'development';
+import { axiosInstance } from './axiosInstance';
 
 /**
  * 카카오 로그인 요청
@@ -10,7 +10,7 @@ const isDev = import.meta.env.MODE === 'development';
  * - prod: 쿠키(HttpOnly) 기반 자동 저장, 별도 응답 처리 없음
  */
 export const kakaoLogin = async (code: string) => {
-  const endpoint = isDev ? '/auth/kakao/login/dev' : '/auth/kakao/login';
+  const endpoint = IS_DEV ? '/auth/kakao/login/dev' : '/auth/kakao/login';
 
   try {
     const response = await axios.get(endpoint, {
@@ -18,7 +18,7 @@ export const kakaoLogin = async (code: string) => {
     });
 
     // 개발환경일 경우 accessToken, refreshToken 반환
-    if (isDev) {
+    if (IS_DEV) {
       return {
         accessToken: response.data.content.accessToken,
         refreshToken: response.data.content.refreshToken,
@@ -39,10 +39,10 @@ export const kakaoLogin = async (code: string) => {
  * - prod: 쿠키 기반 로그아웃
  */
 export const kakaoLogout = async () => {
-  const endpoint = isDev ? '/auth/kakao/logout/dev' : '/auth/kakao/logout';
+  const endpoint = IS_DEV ? '/auth/kakao/logout/dev' : '/auth/kakao/logout';
 
   try {
-    const body = isDev ? { refreshToken: localStorage.getItem('refreshToken') } : undefined; // prod는 쿠키 기반이라 body 비움
+    const body = IS_DEV ? { refreshToken: localStorage.getItem('refreshToken') } : undefined; // prod는 쿠키 기반이라 body 비움
 
     await axiosInstance.post(endpoint, body);
   } catch (error) {
@@ -73,5 +73,19 @@ export const getAccessTokenFromCookie = async () => {
   } catch (error) {
     console.error('get access cookie failed:', error);
     throw error;
+  }
+};
+
+/**
+ * 서버에 쿠키 기반 인증 상태 확인 요청
+ * @returns 인증 성공 시 true, 실패 시 false
+ */
+export const verifyAuth = async (): Promise<boolean> => {
+  try {
+    await axios.get('/auth/verify'); // 200 OK 시 인증됨
+    return true;
+  } catch (err) {
+    console.log('verify auth failed:', err);
+    return false;
   }
 };

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,6 +1,6 @@
 import axios, { type InternalAxiosRequestConfig } from 'axios';
 
-const isDev = import.meta.env.MODE === 'development';
+import { IS_DEV } from '@/constants/env';
 
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL,
@@ -10,7 +10,7 @@ export const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     // 개발환경일 때만 accessToken 헤더 추가
-    if (isDev) {
+    if (IS_DEV) {
       const accessToken = localStorage.getItem('accessToken');
       if (accessToken) {
         config.headers['Authorization'] = `Bearer ${accessToken}`;
@@ -33,7 +33,7 @@ axiosInstance.interceptors.response.use(
       try {
         const newAccessToken = await refreshAccessToken();
 
-        if (isDev && newAccessToken) {
+        if (IS_DEV && newAccessToken) {
           originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
         }
 
@@ -54,11 +54,11 @@ axiosInstance.interceptors.response.use(
  */
 const refreshAccessToken = async () => {
   try {
-    const body = isDev ? { refreshToken: localStorage.getItem('refreshToken') } : undefined;
+    const body = IS_DEV ? { refreshToken: localStorage.getItem('refreshToken') } : undefined;
 
     const response = await axiosInstance.post('/auth/refresh', body);
 
-    if (isDev) {
+    if (IS_DEV) {
       const newAccessToken = response.data.content.accessToken;
       localStorage.setItem('accessToken', newAccessToken);
       return newAccessToken;

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,0 +1,1 @@
+export const IS_DEV = import.meta.env.MODE === 'development';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import axios from 'axios';
 import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
 
-import './index.css';
 import App from './App.tsx';
+import { store } from './store/store.ts';
+import './index.css';
 
 axios.defaults.baseURL = import.meta.env.VITE_BACKEND_URL;
 axios.defaults.withCredentials = true;
 
-createRoot(document.getElementById('root')!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <Provider store={store}>
+    <App />
+  </Provider>
+);

--- a/src/pages/AuthRedirectPage.tsx
+++ b/src/pages/AuthRedirectPage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
-import { getAccessTokenFromCookie, kakaoLogin } from '@/apis/auth';
+import { kakaoLogin } from '@/apis/auth';
 import { IS_DEV } from '@/constants/env';
 
 export const AuthRedirectPage = () => {
@@ -22,7 +22,7 @@ export const AuthRedirectPage = () => {
         }
 
         if (!IS_DEV) {
-          await getAccessTokenFromCookie(); // ✅ prod 환경에서 AT 쿠키 설정
+          // ✅ prod 환경에서 AT 쿠키 설정
         }
 
         navigate('/signup/pet'); // TODO: 추후 반려동물 유무에 따라 navigate 경로 수정 필요.

--- a/src/pages/AuthRedirectPage.tsx
+++ b/src/pages/AuthRedirectPage.tsx
@@ -3,8 +3,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { getAccessTokenFromCookie, kakaoLogin } from '@/apis/auth';
-
-const isDev = import.meta.env.MODE === 'development';
+import { IS_DEV } from '@/constants/env';
 
 export const AuthRedirectPage = () => {
   const navigate = useNavigate();
@@ -17,12 +16,12 @@ export const AuthRedirectPage = () => {
       try {
         const result = await kakaoLogin(code);
 
-        if (isDev && result) {
+        if (IS_DEV && result) {
           localStorage.setItem('accessToken', result.accessToken);
           localStorage.setItem('refreshToken', result.refreshToken);
         }
 
-        if (!isDev) {
+        if (!IS_DEV) {
           await getAccessTokenFromCookie(); // ✅ prod 환경에서 AT 쿠키 설정
         }
 

--- a/src/pages/TokenRedirectPage.tsx
+++ b/src/pages/TokenRedirectPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+
+import { useDispatch } from 'react-redux';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { axiosInstance } from '@/apis/axiosInstance';
+import { IS_DEV } from '@/constants/env';
+import { setTokens, setIsNewUser } from '@/store/authSlice';
+
+/**
+ * 카카오 인증 후, 서버에서 리디렉션 되는 페이지
+ * 리디렉션 되면서 리턴값과 쿠키 설정이 무시되므로, 쿠키 설정 요청을 직접 보냄.
+ */
+export const TokenRedirectPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const accessToken = searchParams.get('access_token');
+    const refreshToken = searchParams.get('refresh_token');
+
+    if (!accessToken || !refreshToken) {
+      console.error('❌ 토큰이 없습니다. 로그인 페이지로 이동합니다.');
+      navigate('/login');
+      return;
+    }
+
+    // 1. Redux에 토큰 저장
+    dispatch(setTokens({ accessToken, refreshToken }));
+
+    // 2. 개발환경: 로컬스토리지 저장
+    if (IS_DEV) {
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+      console.info('✅ 개발환경: 토큰을 localStorage에 저장했습니다.');
+      navigate('/signup/pet'); // 개발환경에선 쿠키 설정 없이 바로 이동
+      return;
+    }
+
+    // 3. 운영환경: 쿠키 설정 API 호출
+    const setCookie = async () => {
+      try {
+        const res = await axiosInstance.post('/api/auth/cookie', {
+          accessToken,
+          refreshToken,
+        });
+
+        const { isNewUser } = res.data;
+
+        dispatch(setIsNewUser(isNewUser));
+
+        if (isNewUser) {
+          navigate('/signup/pet');
+        } else {
+          navigate('/');
+        }
+      } catch (err) {
+        console.error('❌ 쿠키 설정 실패', err);
+        navigate('/login');
+      }
+    };
+
+    setCookie();
+  }, [dispatch, navigate, searchParams]);
+
+  return <p>로그인 처리 중입니다...</p>;
+};

--- a/src/routes/PrivateRouter.tsx
+++ b/src/routes/PrivateRouter.tsx
@@ -1,6 +1,48 @@
+import { useEffect, useState } from 'react';
+
+import { useSelector } from 'react-redux';
 import { Navigate, Outlet } from 'react-router-dom';
 
+import { verifyAuth } from '@/apis/auth';
+import { IS_DEV } from '@/constants/env';
+import type { RootState } from '@/store/store';
+
 export const PrivateRouter = () => {
-  const accessToken = localStorage.getItem('accessToken');
-  return accessToken ? <Outlet /> : <Navigate to="/login" replace />;
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+
+  const accessToken = useSelector((state: RootState) => state.auth.accessToken);
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      if (IS_DEV) {
+        // 1. 개발환경: localStorage에 accessToken이 있으면 로그인으로 간주
+        const accessToken = localStorage.getItem('accessToken');
+        setIsAuthenticated(!!accessToken);
+      } else {
+        // 2. 운영환경: 서버에 쿠키가 존재하는지 verifyAuth로 확인
+        try {
+          const result = await verifyAuth(); // boolean 응답 예상
+          setIsAuthenticated(result);
+        } catch (e) {
+          console.error('❌ 인증 검증 실패', e);
+
+          // 임시로 Redux 상태에 accessToken이 있으면 인증된 것으로 간주
+          if (accessToken) {
+            console.warn('Redux에 accessToken 존재 → 인증된 것으로 간주');
+            setIsAuthenticated(true);
+          } else {
+            setIsAuthenticated(false);
+          }
+        }
+      }
+    };
+
+    checkAuth();
+  }, []);
+
+  if (isAuthenticated === null) {
+    return <div>로그인 검사 중...</div>; // 필요 시 Skeleton 처리 가능
+  }
+
+  return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -11,6 +11,7 @@ import { LoginPage } from '@/pages/LoginPage';
 import { MyPage } from '@/pages/MyPage';
 import { SignupPetRegisterPage } from '@/pages/SignupPetRegisterPage';
 import { SlotSettingPage } from '@/pages/SlotSettingPage';
+import { TokenRedirectPage } from '@/pages/TokenRedirectPage';
 import { WithdrawPage } from '@/pages/WithdrawPage';
 
 import { PrivateRouter } from './PrivateRouter';
@@ -21,6 +22,7 @@ export const router = createBrowserRouter([
     children: [
       { path: '/login', element: <LoginPage /> },
       { path: '/api/auth/kakao/login/dev', element: <AuthRedirectPage /> },
+      { path: '/token', element: <TokenRedirectPage /> },
     ],
   },
   {

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  isLoggedIn: boolean;
+  isNewUser?: boolean;
+}
+
+const initialState: AuthState = {
+  accessToken: null,
+  refreshToken: null,
+  isLoggedIn: false,
+  isNewUser: undefined,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setTokens: (state, action: PayloadAction<{ accessToken: string; refreshToken: string }>) => {
+      state.accessToken = action.payload.accessToken;
+      state.refreshToken = action.payload.refreshToken;
+      state.isLoggedIn = true;
+    },
+    setIsNewUser: (state, action: PayloadAction<boolean>) => {
+      state.isNewUser = action.payload;
+    },
+    logout: () => initialState,
+  },
+});
+
+export const { setTokens, setIsNewUser, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import authReducer from './authSlice';
+
+export const store = configureStore({
+  reducer: {
+    auth: authReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 카카오 인증 후 `/token` 경로에서 쿠키 설정 API를 직접 호출하도록 수정

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #43

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- 기존에 존재하지 않던 `/token` 라우트에 대응하는 `TokenRedirectPage` 컴포넌트 추가
- 개발환경(`IS_DEV`)과 운영환경(`!IS_DEV`)을 분기하여 처리
  - 개발환경: `localStorage`에 accessToken, refreshToken 저장 후 `/signup/pet`로 이동
  - 운영환경: 백엔드에 쿠키 설정 API 요청 → 신규 회원 여부에 따라 `/signup/pet` 또는 `/` 분기
- `/token` 경로가 라우터에 명확히 정의되도록 수정 (`PlainLayout` 하위에 등록)
- 쿠키 설정이 302 redirect 이후 무시되지 않도록 명시적으로 POST 요청

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [ ] 카카오 로그인 → `token` 페이지 진입 후 자동 분기 확인
- [ ] 개발환경: localStorage 저장 및 `/signup/pet` 이동 확인
- [ ] 운영환경: 쿠키 설정 API 호출 및 응답 기반 라우팅 확인
- [ ] 기존 페이지 접근 시 인증되지 않은 경우 `/login`으로 redirect 처리 정상 작동

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
- 관련 release: `v0.1.0`
- 기존 AuthRedirectPage는 사용되지 않지만, 제거하지 않고 남겨둔 상태입니다.