### PR TITLE
feat: 개발환경 로그인 리디렉션 수정 및 일정 CRUD API 연동

### DIFF
--- a/src/apis/alarm.ts
+++ b/src/apis/alarm.ts
@@ -1,0 +1,44 @@
+import { axiosInstance } from './axiosInstance'; // 환경에 맞게 경로 수정
+import type { ApiResponse } from '../types/common'; // ApiResponse 정의가 있는 위치 기준
+
+// 일정 개체 타입
+export interface Schedule {
+  scheduleId: number;
+  title: string;
+  content: string;
+  targetDate: string; // 'YYYY-MM-DD'
+}
+
+// 일정 등록/수정 시 사용하는 Form 데이터 타입
+export interface ScheduleFormData {
+  title: string;
+  content: string;
+  targetDate?: string; // 등록 시 필요, 수정 시 선택
+}
+
+// 📌 일정 등록: POST /api/schedules/{petId}
+export const createSchedule = async (petId: number, data: ScheduleFormData) => {
+  const res = await axiosInstance.post<ApiResponse<Schedule>>(`/api/schedules/${petId}`, data);
+  return res.data.content;
+};
+
+// 📌 일정 삭제: DELETE /api/schedules/{scheduleId}
+export const deleteSchedule = async (scheduleId: number) => {
+  const res = await axiosInstance.delete<ApiResponse<null>>(`/api/schedules/${scheduleId}`);
+  return res.data.content;
+};
+
+// 📌 일정 수정: PATCH /api/schedules/{scheduleId}
+export const updateSchedule = async (scheduleId: number, data: ScheduleFormData) => {
+  const res = await axiosInstance.patch<ApiResponse<Schedule>>(
+    `/api/schedules/${scheduleId}`,
+    data
+  );
+  return res.data.content;
+};
+
+// 📌 전체 일정 조회: GET /api/schedules/{petId}/all
+export const getAllSchedules = async (petId: number) => {
+  const res = await axiosInstance.get<ApiResponse<Schedule[]>>(`/api/schedules/${petId}/all`);
+  return res.data.content;
+};

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 import { IS_DEV } from '@/constants/env';
 
 import { axiosInstance } from './axiosInstance';
@@ -14,7 +12,7 @@ export const kakaoLogin = async (code: string) => {
 
   try {
     // 302 redirect 목적의 요청만 수행 (개발 환경만 실행)
-    await axios.get(endpoint, {
+    await axiosInstance.get(endpoint, {
       params: { code },
     });
   } catch (error) {

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -13,20 +13,10 @@ export const kakaoLogin = async (code: string) => {
   const endpoint = IS_DEV ? '/auth/kakao/login/dev' : '/auth/kakao/login';
 
   try {
-    const response = await axios.get(endpoint, {
+    // 302 redirect 목적의 요청만 수행 (개발 환경만 실행)
+    await axios.get(endpoint, {
       params: { code },
     });
-
-    // 개발환경일 경우 accessToken, refreshToken 반환
-    if (IS_DEV) {
-      return {
-        accessToken: response.data.content.accessToken,
-        refreshToken: response.data.content.refreshToken,
-      };
-    }
-
-    // 배포 환경은 쿠키 기반 저장 → 응답 별도 처리 없음
-    return null;
   } catch (error) {
     console.error('kakao login failed:', error);
     throw error;

--- a/src/components/PetRegisterForm.tsx
+++ b/src/components/PetRegisterForm.tsx
@@ -79,6 +79,7 @@ export const PetRegisterForm = ({ form, setForm, onFormValidChange }: PetRegiste
         label="생일"
         value={form.birthDate}
         onChange={birthDate => setForm({ ...form, birthDate })}
+        withYearSelect
       />
     </FormSection>
   );

--- a/src/pages/AuthRedirectPage.tsx
+++ b/src/pages/AuthRedirectPage.tsx
@@ -3,29 +3,22 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { kakaoLogin } from '@/apis/auth';
-import { IS_DEV } from '@/constants/env';
 
 export const AuthRedirectPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');
-    if (!code) return;
+    if (!code) {
+      console.error('❌ 인가 코드 없음');
+      navigate('/login');
+      return;
+    }
 
     const getToken = async () => {
       try {
-        const result = await kakaoLogin(code);
-
-        if (IS_DEV && result) {
-          localStorage.setItem('accessToken', result.accessToken);
-          localStorage.setItem('refreshToken', result.refreshToken);
-        }
-
-        if (!IS_DEV) {
-          // ✅ prod 환경에서 AT 쿠키 설정
-        }
-
-        navigate('/signup/pet'); // TODO: 추후 반려동물 유무에 따라 navigate 경로 수정 필요.
+        await kakaoLogin(code); // API 호출만 수행
+        // 이후 자동 302 리디렉션이 일어나서 /token 으로 이동
       } catch (err) {
         console.error('로그인 실패', err);
         navigate('/login');

--- a/src/pages/AuthRedirectPage.tsx
+++ b/src/pages/AuthRedirectPage.tsx
@@ -2,8 +2,6 @@ import { useEffect } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
-import { kakaoLogin } from '@/apis/auth';
-
 export const AuthRedirectPage = () => {
   const navigate = useNavigate();
 
@@ -15,17 +13,20 @@ export const AuthRedirectPage = () => {
       return;
     }
 
-    const getToken = async () => {
-      try {
-        await kakaoLogin(code); // API 호출만 수행
-        // 이후 자동 302 리디렉션이 일어나서 /token 으로 이동
-      } catch (err) {
-        console.error('로그인 실패', err);
-        navigate('/login');
-      }
-    };
+    // 브라우저가 직접 백엔드로 이동하여 302 리디렉션을 따르도록 함
+    window.location.href = `${import.meta.env.VITE_BACKEND_URL}/auth/kakao/login/dev?code=${code}`;
 
-    getToken();
+    // const getToken = async () => {
+    //   try {
+    //     await kakaoLogin(code); // API 호출만 수행
+    //     // 이후 자동 302 리디렉션이 일어나서 /token 으로 이동
+    //   } catch (err) {
+    //     console.error('로그인 실패', err);
+    //     navigate('/login');
+    //   }
+    // };
+
+    // getToken();
   }, []);
 
   return <div>로그인 중</div>;

--- a/src/pages/SignupPetRegisterPage.tsx
+++ b/src/pages/SignupPetRegisterPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { PetRegisterForm } from '@/components/PetRegisterForm';
+import { setPetForm } from '@/store/petSlice';
 import type { PetForm } from '@/types/form';
 
 export const SignupPetRegisterPage = () => {
@@ -15,6 +17,7 @@ export const SignupPetRegisterPage = () => {
   });
   const [isPetFormValid, setIsPetFormValid] = useState(false);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   return (
     <Container>
@@ -22,7 +25,13 @@ export const SignupPetRegisterPage = () => {
 
       <PetRegisterForm form={form} setForm={setForm} onFormValidChange={setIsPetFormValid} />
 
-      <NextButton onClick={() => navigate('/slot')} disabled={!isPetFormValid}>
+      <NextButton
+        onClick={() => {
+          dispatch(setPetForm(form));
+          navigate('/slot');
+        }}
+        disabled={!isPetFormValid}
+      >
         다음
       </NextButton>
     </Container>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -21,7 +21,7 @@ export const router = createBrowserRouter([
     element: <PlainLayout />,
     children: [
       { path: '/login', element: <LoginPage /> },
-      { path: '/api/auth/kakao/login/dev', element: <AuthRedirectPage /> },
+      { path: '/oauth/redirect', element: <AuthRedirectPage /> },
       { path: '/token', element: <TokenRedirectPage /> },
     ],
   },

--- a/src/store/petSlice.ts
+++ b/src/store/petSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { PetForm } from '@/types/form';
+
+const initialState: PetForm = {
+  name: '',
+  species: '강아지',
+  gender: '남아',
+  birthDate: new Date(),
+};
+
+const petSlice = createSlice({
+  name: 'pet',
+  initialState,
+  reducers: {
+    setPetForm: (state, action: PayloadAction<PetForm>) => {
+      state.name = action.payload.name;
+      state.species = action.payload.species;
+      state.gender = action.payload.gender;
+      state.birthDate = action.payload.birthDate;
+    },
+    resetPetForm: state => {
+      state.name = initialState.name;
+      state.species = initialState.species;
+      state.gender = initialState.gender;
+      state.birthDate = initialState.birthDate;
+    },
+  },
+});
+
+export const { setPetForm, resetPetForm } = petSlice.actions;
+export default petSlice.reducer;

--- a/src/utils/transform/alarm.ts
+++ b/src/utils/transform/alarm.ts
@@ -1,0 +1,18 @@
+import type { Schedule, ScheduleFormData } from '@/apis/alarm';
+import type { Alarm } from '@/types/alarm';
+import { formatDate } from '@/utils/calendar'; // 너가 정의한 함수
+
+// 🔄 Alarm → API 전송용 ScheduleFormData (등록/수정용 Body)
+export const toScheduleFormData = (alarm: Alarm): ScheduleFormData => ({
+  title: alarm.title,
+  content: alarm.description,
+  targetDate: formatDate(alarm.startDate), // 'YYYY-MM-DD' 형식으로 변환
+});
+
+// 🔄 Schedule(API 응답) → Alarm(UI에서 사용하는 객체)
+export const toAlarm = (schedule: Schedule): Alarm => ({
+  id: schedule.scheduleId,
+  title: schedule.title,
+  description: schedule.content,
+  startDate: new Date(schedule.targetDate), // string → Date 객체로 복원
+});


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 개발환경 카카오 리디렉션 URI 변경 및 직접 백엔드 /login/dev API 호출
- 일정 등록/조회/수정/삭제 API 연동 로직 구현
- CustomDatePicker 년도 선택 기능 추가
- 반려동물 정보 입력 페이지 폼 데이터 전역상태로 관리

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #46 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- 자동으로 카카오 리디렉션 URI로 백엔드 login API 호출하는 것과 달리,
개발환경에서는 AuthRedirectPage에서 직접 code를 파라미터로 백엔드 login/dev API를 호출함.
- 일정 API 연결
- `PetRegisterForm.tsx`를 사용하는 경우만 폼 데이터 전역 상태 관리

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [x] 개발환경 카카오 로그인 정상 동작함
- [ ] 일정 등록 시 API 요청이 성공하고, 리스트에 반영됨
- [ ] 일정 수정 시 UI와 서버 상태가 일치함
- [ ] 일정 삭제 시 정상적으로 삭제되고 목록에서도 제거됨
- [ ] 조회 API 호출 시, 유저 일정이 정확히 렌더링됨
- [x] CustomDatePicker에서 년도 선택에 따른 달력이 보임

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
개발환경에서 로그인 동작을 우선 확인하기 위해, API 연동 전 먼저 PR 올립니다..!