### PR TITLE
feat: 반려동물 정보 등록 API 연동 및 일정 API 연동 마무리 (KB3-98)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,31 @@
+import { useEffect } from 'react';
+
+import { useDispatch } from 'react-redux';
 import { RouterProvider } from 'react-router-dom';
 
 import { router } from './routes/Router';
+import { setSelectedPetId } from './store/petSlice';
+
+const AppInitializer = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const storedId = localStorage.getItem('selectedPetId');
+    if (storedId) {
+      dispatch(setSelectedPetId(Number(storedId)));
+    }
+  }, [dispatch]);
+
+  return null;
+};
 
 const App = () => {
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <AppInitializer />
+      <RouterProvider router={router} />
+    </>
+  );
 };
 
 export default App;

--- a/src/apis/alarm.ts
+++ b/src/apis/alarm.ts
@@ -1,15 +1,15 @@
 import { axiosInstance } from './axiosInstance'; // 환경에 맞게 경로 수정
 import type { ApiResponse } from '../types/common'; // ApiResponse 정의가 있는 위치 기준
 
-// 일정 개체 타입
-export interface Schedule {
+// API 응답 전용 타입
+export interface ScheduleApiResponse {
   scheduleId: number;
   title: string;
   content: string;
-  targetDate: string; // 'YYYY-MM-DD'
+  targetDate: string; // YYYY-MM-DD
 }
 
-// 일정 등록/수정 시 사용하는 Form 데이터 타입
+// API 요청 바디 (등록/수정 시 사용)
 export interface ScheduleFormData {
   title: string;
   content: string;
@@ -17,28 +17,39 @@ export interface ScheduleFormData {
 }
 
 // 📌 일정 등록: POST /api/schedules/{petId}
-export const createSchedule = async (petId: number, data: ScheduleFormData) => {
-  const res = await axiosInstance.post<ApiResponse<Schedule>>(`/api/schedules/${petId}`, data);
+export const createSchedule = async (
+  petId: number,
+  data: ScheduleFormData
+): Promise<ScheduleApiResponse> => {
+  const res = await axiosInstance.post<ApiResponse<ScheduleApiResponse>>(
+    `/schedules/${petId}`,
+    data
+  );
   return res.data.content;
 };
 
 // 📌 일정 삭제: DELETE /api/schedules/{scheduleId}
-export const deleteSchedule = async (scheduleId: number) => {
-  const res = await axiosInstance.delete<ApiResponse<null>>(`/api/schedules/${scheduleId}`);
+export const deleteSchedule = async (scheduleId: number): Promise<string> => {
+  const res = await axiosInstance.delete<ApiResponse<string>>(`/schedules/${scheduleId}`);
   return res.data.content;
 };
 
 // 📌 일정 수정: PATCH /api/schedules/{scheduleId}
-export const updateSchedule = async (scheduleId: number, data: ScheduleFormData) => {
-  const res = await axiosInstance.patch<ApiResponse<Schedule>>(
-    `/api/schedules/${scheduleId}`,
+export const updateSchedule = async (
+  scheduleId: number,
+  data: ScheduleFormData
+): Promise<ScheduleApiResponse> => {
+  const res = await axiosInstance.patch<ApiResponse<ScheduleApiResponse>>(
+    `/schedules/${scheduleId}`,
     data
   );
   return res.data.content;
 };
 
 // 📌 전체 일정 조회: GET /api/schedules/{petId}/all
-export const getAllSchedules = async (petId: number) => {
-  const res = await axiosInstance.get<ApiResponse<Schedule[]>>(`/api/schedules/${petId}/all`);
+export const getAllSchedules = async (petId: number): Promise<ScheduleApiResponse[]> => {
+  const res = await axiosInstance.get<ApiResponse<ScheduleApiResponse[]>>(
+    `/schedules/${petId}/all`
+  );
   return res.data.content;
 };

--- a/src/apis/pets.ts
+++ b/src/apis/pets.ts
@@ -1,10 +1,50 @@
+import type { ApiResponse } from '@/types/common';
+import type { PetForm, PetInfo } from '@/types/form';
+import { formatDate } from '@/utils/calendar';
+
 import { axiosInstance } from './axiosInstance';
 
-export const getPets = async () => {
-  try {
-    await axiosInstance.get('pets');
-  } catch (error) {
-    console.log('pets', error);
-    throw error;
+// export const getPets = async () => {
+//   try {
+//     await axiosInstance.get('pets');
+//   } catch (error) {
+//     console.log('pets', error);
+//     throw error;
+//   }
+// };
+
+export interface PetApiResponse {
+  id: number;
+  name: string;
+  type: string;
+  gender: string;
+  birthDate: string; // ISO-8601 문자열
+  isFavorite: boolean;
+}
+
+export const registerPet = async (form: PetForm): Promise<PetInfo> => {
+  const payload = {
+    name: form.name,
+    type: form.species,
+    gender: form.gender,
+    birthDate: formatDate(form.birthDate), // string (YYYY-MM-DD)
+    isFavorite: true,
+  };
+
+  const res = await axiosInstance.post<ApiResponse<PetApiResponse>>('/pets', payload);
+
+  if (!res.data.success || !res.data.content) {
+    throw new Error(res.data.message || '반려동물 등록 실패');
   }
+
+  // ✅ API 응답 → 내부 도메인 타입으로 가공
+  const petInfo: PetInfo = {
+    id: res.data.content.id,
+    name: res.data.content.name,
+    species: res.data.content.type, // API는 type, 내부는 species
+    gender: res.data.content.gender,
+    birthDate: new Date(res.data.content.birthDate),
+  };
+
+  return petInfo;
 };

--- a/src/features/alarm/ScheduleRegisterModal.tsx
+++ b/src/features/alarm/ScheduleRegisterModal.tsx
@@ -8,6 +8,7 @@ import { FormInput } from '@/components/common/FormInput';
 import { FormTextarea } from '@/components/common/FormTextarea';
 import { CustomDatePicker } from '@/components/CustomDatePicker';
 import type { Alarm } from '@/types/alarm';
+import { validators } from '@/utils/validators';
 
 interface ScheduleRegisterModalProps {
   isOpen: boolean;
@@ -34,7 +35,11 @@ export const ScheduleRegisterModal = ({
   useEffect(() => {
     if (isOpen) {
       setAlarm(initialAlarm);
-      setFormValidity({ startDate: true, title: false, content: false });
+      setFormValidity({
+        startDate: true,
+        title: validators.title(initialAlarm.title).isValid,
+        content: validators.content(initialAlarm.description).isValid,
+      });
     }
   }, [isOpen, initialAlarm]);
 

--- a/src/hooks/useRegisterPet.ts
+++ b/src/hooks/useRegisterPet.ts
@@ -1,0 +1,41 @@
+// hooks/useRegisterPet.ts
+import { useState } from 'react';
+
+import { registerPet } from '@/apis/pets';
+import type { PetForm, PetInfo } from '@/types/form';
+import { handleAxiosError } from '@/utils/handleAxiosError';
+
+interface UseRegisterPetResult {
+  register: (form: PetForm) => Promise<PetInfo | null>;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * 반려동물 등록 훅
+ * - registerPet API 호출
+ * - 에러/로딩 상태 관리
+ * - PetInfo 반환
+ */
+export const useRegisterPet = (): UseRegisterPetResult => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const register = async (form: PetForm): Promise<PetInfo | null> => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const petInfo = await registerPet(form); // ✅ PetInfo 직접 반환
+      return petInfo;
+    } catch (err) {
+      const message = handleAxiosError(err);
+      setError(message);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { register, loading, error };
+};

--- a/src/pages/AlarmPage.tsx
+++ b/src/pages/AlarmPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { createSchedule, deleteSchedule, getAllSchedules, updateSchedule } from '@/apis/alarm';
@@ -7,6 +8,7 @@ import { ConfirmDeleteModal } from '@/components/common/ConfirmDeleteModal';
 import { ScheduleAlarmItem } from '@/features/alarm/ScheduleAlarmItem';
 import { ScheduleRegisterModal } from '@/features/alarm/ScheduleRegisterModal';
 import { useModal } from '@/hooks/useModal';
+import type { RootState } from '@/store/store';
 import type { Alarm } from '@/types/alarm';
 import { toAlarm, toScheduleFormData } from '@/utils/transform/alarm';
 
@@ -26,13 +28,14 @@ export const AlarmPage = () => {
   const [editingAlarm, setEditingAlarm] = useState<Alarm>(createEmptyAlarm());
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
 
-  const petId = 2; // 예시용, 실제로는 props/context에서 주입
+  // ✅ 전역 상태에서 selectedPet.id 추출
+  const petId = useSelector((state: RootState) => state.selectedPet.id);
 
   // 🟢 API 연동: 알람 전체 불러오기
   useEffect(() => {
     const fetch = async () => {
       try {
-        const res = await getAllSchedules(petId);
+        const res = await getAllSchedules(petId ?? -1);
         setAlarmList(res.map(toAlarm));
       } catch (e) {
         console.error('알람 불러오기 실패', e);
@@ -50,7 +53,7 @@ export const AlarmPage = () => {
         const updated = await updateSchedule(submittedAlarm.id, formData);
         setAlarmList(prev => addOrUpdateAlarmList(prev, toAlarm(updated)));
       } else {
-        const created = await createSchedule(petId, formData);
+        const created = await createSchedule(petId ?? -1, formData);
         setAlarmList(prev => addOrUpdateAlarmList(prev, toAlarm(created)));
       }
       closeModal();
@@ -74,10 +77,27 @@ export const AlarmPage = () => {
 
   const isEditing = (list: Alarm[], target: Alarm) => list.some(alarm => alarm.id === target.id);
 
-  const addOrUpdateAlarmList = (list: Alarm[], target: Alarm): Alarm[] =>
-    isEditing(list, target)
-      ? list.map(alarm => (alarm.id === target.id ? target : alarm))
-      : [...list, target];
+  // const addOrUpdateAlarmList = (list: Alarm[], target: Alarm): Alarm[] =>
+  //   isEditing(list, target)
+  //     ? list.map(alarm => (alarm.id === target.id ? target : alarm))
+  //     : [...list, target];
+
+  const addOrUpdateAlarmList = (list: Alarm[], target: Alarm): Alarm[] => {
+    const index = list.findIndex(alarm => alarm.id === target.id);
+    let newList: Alarm[];
+
+    if (index === -1) {
+      // 신규 알람 추가
+      newList = [...list, { ...target }];
+    } else {
+      // 기존 알람 수정
+      newList = [...list];
+      newList[index] = { ...target };
+    }
+
+    // 🔁 날짜 기준 오름차순 정렬 (가까운 날짜가 위로)
+    return newList.sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
+  };
 
   const deleteAlarmById = (list: Alarm[], targetId: number): Alarm[] =>
     list.filter(alarm => alarm.id !== targetId);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { Backpack } from 'lucide-react';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -8,12 +9,15 @@ import { TodayBar } from '@/features/home/TodayBar';
 import { Routine } from '@/features/routine/Routine';
 import { useBriefCardData } from '@/hooks/useBriefCardData';
 import { nameListMock } from '@/mocks/homeData';
+import type { RootState } from '@/store/store';
 
 import Logo from '@/assets/icons/logo.svg?react';
 
 export const HomePage = () => {
-  const petId = 2; // 실제로는 전역 상태나 route param에서 가져오겠죠
-  const { schedules, remarks, loading, error } = useBriefCardData(petId);
+  // ✅ 전역 상태에서 selectedPet.id 추출
+  const petId = useSelector((state: RootState) => state.selectedPet.id);
+
+  const { schedules, remarks, loading, error } = useBriefCardData(petId ?? -1);
 
   const navigate = useNavigate();
   return (

--- a/src/pages/SignupPetRegisterPage.tsx
+++ b/src/pages/SignupPetRegisterPage.tsx
@@ -5,7 +5,8 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { PetRegisterForm } from '@/components/PetRegisterForm';
-import { setPetForm } from '@/store/petSlice';
+import { useRegisterPet } from '@/hooks/useRegisterPet';
+import { setSelectedPet, setSelectedPetId } from '@/store/petSlice';
 import type { PetForm } from '@/types/form';
 
 export const SignupPetRegisterPage = () => {
@@ -16,8 +17,24 @@ export const SignupPetRegisterPage = () => {
     birthDate: new Date(),
   });
   const [isPetFormValid, setIsPetFormValid] = useState(false);
+
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const { register, loading, error } = useRegisterPet();
+
+  const handleNextClick = async () => {
+    if (!isPetFormValid || loading) return;
+
+    const petInfo = await register(form); // ✅ id 포함 결과
+
+    if (petInfo) {
+      dispatch(setSelectedPet(petInfo)); // ✅ 전역 상태로 저장
+      dispatch(setSelectedPetId(petInfo.id)); // localStorage에 id만 따로 저장
+      navigate('/slot');
+    } else if (error) {
+      alert(error);
+    }
+  };
 
   return (
     <Container>
@@ -25,14 +42,10 @@ export const SignupPetRegisterPage = () => {
 
       <PetRegisterForm form={form} setForm={setForm} onFormValidChange={setIsPetFormValid} />
 
-      <NextButton
-        onClick={() => {
-          dispatch(setPetForm(form));
-          navigate('/slot');
-        }}
-        disabled={!isPetFormValid}
-      >
-        다음
+      {error && <ErrorMessage>{error}</ErrorMessage>}
+
+      <NextButton onClick={handleNextClick} disabled={!isPetFormValid || loading}>
+        {loading ? '등록 중...' : '다음'}
       </NextButton>
     </Container>
   );
@@ -48,6 +61,13 @@ const Container = styled.div`
 const Title = styled.h2`
   text-align: center;
   padding: 18px 0;
+`;
+
+const ErrorMessage = styled.p`
+  color: red;
+  font-size: 14px;
+  margin: 8px 0;
+  text-align: center;
 `;
 
 const NextButton = styled.button<{ disabled?: boolean }>`

--- a/src/store/petSlice.ts
+++ b/src/store/petSlice.ts
@@ -1,8 +1,21 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import type { PetForm } from '@/types/form';
+interface SelectedPetState {
+  id: number | null;
+  name: string;
+  species: string;
+  gender: string;
+  birthDate: Date;
+}
 
-const initialState: PetForm = {
+// ✅ id만 localStorage에서 불러오기
+const loadSelectedPetId = (): number | null => {
+  const stored = localStorage.getItem('selectedPetId');
+  return stored ? Number(stored) : null;
+};
+
+const initialState: SelectedPetState = {
+  id: loadSelectedPetId(),
   name: '',
   species: '강아지',
   gender: '남아',
@@ -10,23 +23,29 @@ const initialState: PetForm = {
 };
 
 const petSlice = createSlice({
-  name: 'pet',
+  name: 'selectedPet',
   initialState,
   reducers: {
-    setPetForm: (state, action: PayloadAction<PetForm>) => {
-      state.name = action.payload.name;
-      state.species = action.payload.species;
-      state.gender = action.payload.gender;
-      state.birthDate = action.payload.birthDate;
+    setSelectedPet: (state, action: PayloadAction<SelectedPetState>) => {
+      return { ...action.payload };
     },
-    resetPetForm: state => {
-      state.name = initialState.name;
-      state.species = initialState.species;
-      state.gender = initialState.gender;
-      state.birthDate = initialState.birthDate;
+    resetSelectedPet: () => {
+      localStorage.removeItem('selectedPetId');
+      return {
+        id: null,
+        name: '',
+        species: '강아지',
+        gender: '남아',
+        birthDate: new Date(),
+      };
+    },
+    // ✅ 전용 id 저장 리듀서
+    setSelectedPetId: (state, action: PayloadAction<number>) => {
+      state.id = action.payload;
+      localStorage.setItem('selectedPetId', String(action.payload));
     },
   },
 });
 
-export const { setPetForm, resetPetForm } = petSlice.actions;
+export const { setSelectedPet, resetSelectedPet, setSelectedPetId } = petSlice.actions;
 export default petSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import authReducer from './authSlice';
+import petReducer from './petSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    selectedPet: petReducer,
   },
 });
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -11,3 +11,11 @@ export interface PetForm {
 export interface BaseFieldProps {
   label?: string;
 }
+
+export interface PetInfo {
+  id: number;
+  name: string;
+  species: string;
+  gender: string;
+  birthDate: Date;
+}

--- a/src/utils/transform/alarm.ts
+++ b/src/utils/transform/alarm.ts
@@ -1,4 +1,4 @@
-import type { Schedule, ScheduleFormData } from '@/apis/alarm';
+import type { ScheduleApiResponse, ScheduleFormData } from '@/apis/alarm';
 import type { Alarm } from '@/types/alarm';
 import { formatDate } from '@/utils/calendar'; // 너가 정의한 함수
 
@@ -10,7 +10,7 @@ export const toScheduleFormData = (alarm: Alarm): ScheduleFormData => ({
 });
 
 // 🔄 Schedule(API 응답) → Alarm(UI에서 사용하는 객체)
-export const toAlarm = (schedule: Schedule): Alarm => ({
+export const toAlarm = (schedule: ScheduleApiResponse): Alarm => ({
   id: schedule.scheduleId,
   title: schedule.title,
   description: schedule.content,


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 반려동물 정보 등록 API 연동 및 일정 CRUD API 연동 완료
- localStorage를 통해 전역적으로 현재 선택된 반려동물 id 저장

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #49 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- 반려동물 등록 완료 시 응답값에서 ID 추출하여 전역 상태 및 localStorage에 저장
- 새로고침 후에도 마지막 선택된 반려동물이 유지되도록 로직 구성
- 알람 생성/수정/삭제 API 연동 완료
  - 생성 시 전역 상태의 petId와 함께 전송되도록 수정
  - 수정 시 API 응답값이 제대로 반영되지 않던 이슈 해결
- 알람 수정 시 제목과 내용 입력값이 항상 초기화되던 문제 해결

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [ ] 반려동물 등록 후 새로고침해도 선택된 상태 유지 확인
- [ ] 알람 생성 시 리스트에 즉시 반영됨 확인
- [ ] 알람 수정 시 입력값이 정상적으로 반영됨 확인
- [ ] 알람 삭제 시 리스트에서 제거되는 것 확인

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
- 전역 상태로 선택된 반려동물 ID를 관리하여, 모든 라우팅에서 사용할 수 있도록 했습니다!