### PR TITLE
feat: 달력 특이사항 API 연동 및 마커 상태 전역 관리 (KB3-97)

### DIFF
--- a/src/apis/calendar.ts
+++ b/src/apis/calendar.ts
@@ -1,0 +1,57 @@
+import { axiosInstance } from './axiosInstance';
+import type { ApiResponse } from '../types/common';
+
+// 📌 월간 유무 조회 API 응답
+export interface MonthlyEntry {
+  entryDate: string; // YYYY-MM-DD
+  completed: boolean; // 루틴 완료 여부
+  memo: boolean; // 메모 존재 여부
+  remarked: boolean; // 특이사항 존재 여부
+  scheduled: boolean; // 일정 존재 여부
+}
+
+// 📌 일간 상세 조회 API 응답
+export interface DailyEntryResponse {
+  entryDate: string; // YYYY-MM-DD
+  remarkResponseList: Remark[];
+  routineResponseList: Routine[];
+}
+
+export interface Remark {
+  remarkId: number;
+  title: string;
+  content: string;
+  remarkDate: string; // YYYY-MM-DD
+}
+
+export interface Routine {
+  routineId: number;
+  category: string;
+  status: 'CHECKED' | 'MEMO' | 'UNCHECKED'; // 상태값 제한
+  targetAmount: number;
+  actualAmount: number;
+  content: string;
+  date: string; // YYYY-MM-DD
+}
+
+// 📍 월간 루틴/메모/특이사항/일정 유무 조회
+export const fetchMonthlyEntries = async (
+  petId: number,
+  month: string // 'yyyy-MM' 형식
+): Promise<MonthlyEntry[]> => {
+  const res = await axiosInstance.get<ApiResponse<MonthlyEntry[]>>(
+    `/entries/${petId}/monthly/${month}`
+  );
+  return res.data.content;
+};
+
+// 📍 일간 특이사항 + 루틴 상세 조회
+export const fetchDailyEntries = async (
+  petId: number,
+  date: string // 'yyyy-MM-dd' 형식
+): Promise<DailyEntryResponse> => {
+  const res = await axiosInstance.get<ApiResponse<DailyEntryResponse>>(
+    `/entries/${petId}/daily/${date}`
+  );
+  return res.data.content;
+};

--- a/src/apis/note.ts
+++ b/src/apis/note.ts
@@ -1,0 +1,41 @@
+import { axiosInstance } from './axiosInstance';
+import type { ApiResponse } from '../types/common';
+
+// 응답 타입
+export interface RemarkResponse {
+  remarkId: number;
+  title: string;
+  content: string;
+  remarkDate: string; // YYYY-MM-DD
+}
+
+// 등록/수정 요청 타입
+export interface RemarkFormData {
+  title: string;
+  content: string;
+  remarkDate: string; // YYYY-MM-DD
+}
+
+// 특이사항 등록
+export const createRemark = async (
+  petId: number,
+  data: RemarkFormData
+): Promise<RemarkResponse> => {
+  const res = await axiosInstance.post<ApiResponse<RemarkResponse>>(`/remarks/${petId}`, data);
+  return res.data.content;
+};
+
+// 특이사항 수정
+export const updateRemark = async (
+  remarkId: number,
+  data: Omit<RemarkFormData, 'remarkDate'> // 수정에는 날짜 제외
+): Promise<RemarkResponse> => {
+  const res = await axiosInstance.patch<ApiResponse<RemarkResponse>>(`/remarks/${remarkId}`, data);
+  return res.data.content;
+};
+
+// 특이사항 삭제
+export const deleteRemark = async (remarkId: number): Promise<string> => {
+  const res = await axiosInstance.delete<ApiResponse<string>>(`/remarks/${remarkId}`);
+  return res.data.content;
+};

--- a/src/apis/pets.ts
+++ b/src/apis/pets.ts
@@ -1,12 +1,19 @@
 import type { ApiResponse } from '@/types/common';
-import type { PetForm, PetInfo } from '@/types/form';
+import type { PetForm, PetInfo, PetType } from '@/types/form';
 import { formatDate } from '@/utils/calendar';
 
 import { axiosInstance } from './axiosInstance';
 
-export const getPets = async () => {
+export interface Pet {
+  id: number;
+  name: string;
+  type: PetType;
+  isFavorite: boolean;
+}
+
+export const getPets = async (): Promise<Pet[]> => {
   try {
-    const response = await axiosInstance.get('pets');
+    const response = await axiosInstance.get<ApiResponse<Pet[]>>('pets');
     return response.data.content;
   } catch (error) {
     console.log('pets', error);

--- a/src/constants/calendar.ts
+++ b/src/constants/calendar.ts
@@ -21,7 +21,7 @@ export const DAYS_OF_WEEK = ['일', '월', '화', '수', '목', '금', '토'] as
 
 // 순서를 보장하면서 구조적 데이터를 유지
 export const LEGEND = [
-  { key: 'routine', label: '루틴 체크', color: '#4285F4' },
+  { key: 'completed', label: '루틴 완료', color: '#4285F4' },
   { key: 'memo', label: '메모', color: '#EA4335' },
   { key: 'note', label: '특이사항', color: '#FBBC05' },
 ] as const;

--- a/src/features/calendar/MonthView.tsx
+++ b/src/features/calendar/MonthView.tsx
@@ -9,6 +9,7 @@ interface Props {
   viewDate: Date;
   selectedDate: Date;
   onDateClick: (date: Date) => void;
+  calendarMarks: Record<string, CalendarMarkType[]>;
 }
 
 export const MonthView = ({ viewDate, selectedDate, onDateClick }: Props) => {

--- a/src/features/calendar/MonthView.tsx
+++ b/src/features/calendar/MonthView.tsx
@@ -1,18 +1,22 @@
 import styled from 'styled-components';
 
 import { LEGEND_MAP } from '@/constants/calendar';
-import { MOCK_CALENDAR_MARKS } from '@/mocks/calendarData';
 import type { CalendarMarkType } from '@/types/calendar';
 import { formatDate, getMonthDates, isSameDay, isSameMonth } from '@/utils/calendar';
 
-interface Props {
+interface MonthViewProps {
   viewDate: Date;
   selectedDate: Date;
   onDateClick: (date: Date) => void;
   calendarMarks: Record<string, CalendarMarkType[]>;
 }
 
-export const MonthView = ({ viewDate, selectedDate, onDateClick }: Props) => {
+export const MonthView = ({
+  viewDate,
+  selectedDate,
+  onDateClick,
+  calendarMarks,
+}: MonthViewProps) => {
   const dates = getMonthDates(viewDate); // 월간 날짜 생성
 
   return (
@@ -24,7 +28,7 @@ export const MonthView = ({ viewDate, selectedDate, onDateClick }: Props) => {
         const isSelected = isSameDay(selectedDate, date);
 
         const formatted = formatDate(date);
-        const dots = MOCK_CALENDAR_MARKS[formatted] || [];
+        const dots = calendarMarks[formatted] || [];
         const dotColor = (type: CalendarMarkType) =>
           isInCurrentMonth ? LEGEND_MAP[type].color : '#ddd';
 

--- a/src/features/calendar/WeekView.tsx
+++ b/src/features/calendar/WeekView.tsx
@@ -1,34 +1,18 @@
 import styled from 'styled-components';
 
 import { LEGEND_MAP } from '@/constants/calendar';
-import { MOCK_CALENDAR_MARKS } from '@/mocks/calendarData';
 import type { CalendarMarkType } from '@/types/calendar';
-import { formatDate, isSameDay, isSameMonth } from '@/utils/calendar';
+import { formatDate, getWeekDates, isSameDay, isSameMonth } from '@/utils/calendar';
 
 interface WeekViewProps {
   viewDate: Date;
   selectedDate: Date;
   onDateClick: (date: Date) => void;
+  calendarMarks: Record<string, CalendarMarkType[]>;
 }
 
-// 주간 날짜 생성
-function getWeekDates(date: Date): Date[] {
-  const result: Date[] = [];
-  const dayOfWeek = date.getDay();
-  const sunday = new Date(date);
-  sunday.setDate(date.getDate() - dayOfWeek);
-
-  for (let i = 0; i < 7; i++) {
-    const d = new Date(sunday);
-    d.setDate(sunday.getDate() + i);
-    result.push(d);
-  }
-
-  return result;
-}
-
-export const WeekView = ({ viewDate, selectedDate, onDateClick }: WeekViewProps) => {
-  const dates = getWeekDates(viewDate);
+export const WeekView = ({ viewDate, selectedDate, onDateClick, calendarMarks }: WeekViewProps) => {
+  const dates = getWeekDates(viewDate); // 주간 날짜 생성
 
   return (
     <Grid>
@@ -40,7 +24,7 @@ export const WeekView = ({ viewDate, selectedDate, onDateClick }: WeekViewProps)
         const isViewMatched = isSameDay(selectedDate, viewDate);
 
         const formatted = formatDate(date);
-        const dots = MOCK_CALENDAR_MARKS[formatted] || [];
+        const dots = calendarMarks[formatted] || [];
         const dotColor = (type: CalendarMarkType) =>
           isInCurrentView ? LEGEND_MAP[type].color : '#ddd';
 

--- a/src/features/calendar/WeeklyDetailsSection.tsx
+++ b/src/features/calendar/WeeklyDetailsSection.tsx
@@ -16,6 +16,7 @@ import type { RootState } from '@/store/store';
 import type { Note } from '@/types/note';
 import { formatDate } from '@/utils/calendar';
 import { toRemarkFormData } from '@/utils/transform/note';
+import { toRoutineModel } from '@/utils/transform/routine';
 
 interface WeeklyDetailsSectionProps {
   selectedDate: Date;
@@ -134,7 +135,7 @@ export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps
     setDeleteTargetId(null);
   };
 
-  const routines = data?.routineResponseList ?? [];
+  const routines = data?.routineResponseList?.map(toRoutineModel) ?? [];
 
   return (
     <Wrapper>
@@ -146,7 +147,7 @@ export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps
           <SectionAction onClick={handleAddNote}>특이사항 추가</SectionAction>
         </MarginBottom>
 
-        <RoutineItem petId={selectedPetId ?? -1} />
+        <RoutineItem petId={selectedPetId ?? -1} routines={routines} />
         <NoteItemList notes={notes} onEdit={handleEditNote} onDelete={handleDeleteRequest} />
       </MarginTop>
 
@@ -168,6 +169,7 @@ export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps
 
 const Wrapper = styled.div`
   margin-top: 20px;
+  padding: 0 20px;
 `;
 
 const Divider = styled.div`

--- a/src/features/calendar/WeeklyDetailsSection.tsx
+++ b/src/features/calendar/WeeklyDetailsSection.tsx
@@ -1,8 +1,12 @@
-import { useState } from 'react';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { useEffect, useState } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
+import { fetchDailyEntries } from '@/apis/calendar';
+import { createRemark, deleteRemark, updateRemark, type RemarkResponse } from '@/apis/note';
 import { ConfirmDeleteModal } from '@/components/common/ConfirmDeleteModal';
 import { NoteItemList } from '@/features/calendar/NoteItemList';
 import { NoteModal } from '@/features/calendar/NoteModal';
@@ -10,9 +14,11 @@ import { RoutineItem } from '@/features/routine/RoutineItem';
 import { useModal } from '@/hooks/useModal';
 import type { RootState } from '@/store/store';
 import type { Note } from '@/types/note';
+import { formatDate } from '@/utils/calendar';
+import { toRemarkFormData } from '@/utils/transform/note';
 
 interface WeeklyDetailsSectionProps {
-  selectedDate?: Date;
+  selectedDate: Date;
 }
 
 const createEmptyNote = (): Note => ({
@@ -32,7 +38,7 @@ const deleteNoteById = (list: Note[], targetId: number): Note[] =>
   list.filter(note => note.id !== targetId);
 
 // eslint-disable-next-line no-empty-pattern
-export const WeeklyDetailsSection = ({}: WeeklyDetailsSectionProps) => {
+export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps) => {
   const [notes, setNotes] = useState<Note[]>([]);
   const [editingNote, setEditingNote] = useState<Note>(createEmptyNote());
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
@@ -40,6 +46,28 @@ export const WeeklyDetailsSection = ({}: WeeklyDetailsSectionProps) => {
   const { isOpen: isModalOpen, openModal, closeModal } = useModal();
 
   const selectedPetId = useSelector((state: RootState) => state.selectedPet.id);
+
+  const formattedDate = formatDate(selectedDate); // 'YYYY-MM-DD'
+
+  // ✅ 일간 특이사항 + 루틴 조회 API 호출
+  const { data } = useQuery({
+    queryKey: ['dailyEntries', selectedPetId, formattedDate],
+    queryFn: () => {
+      if (selectedPetId === null) throw new Error('No pet selected');
+      return fetchDailyEntries(selectedPetId, formattedDate);
+    },
+    enabled: selectedPetId !== null,
+  });
+
+  useEffect(() => {
+    const remarks = data?.remarkResponseList ?? [];
+    const transformed: Note[] = remarks.map(r => ({
+      id: r.remarkId,
+      title: r.title,
+      content: r.content,
+    }));
+    setNotes(transformed);
+  }, [data]);
 
   const handleAddNote = () => {
     setEditingNote(createEmptyNote());
@@ -53,24 +81,60 @@ export const WeeklyDetailsSection = ({}: WeeklyDetailsSectionProps) => {
     openModal();
   };
 
-  const handleSubmitNote = (note: Note) => {
-    setNotes(prev => addOrUpdateNoteList(prev, note));
-    closeModal();
+  const handleSubmitNote = async (note: Note) => {
+    if (!selectedPetId) return;
+
+    try {
+      let saved: RemarkResponse;
+
+      if (isEditing(notes, note)) {
+        // 수정
+        saved = await updateRemark(note.id, {
+          title: note.title,
+          content: note.content,
+        });
+      } else {
+        // 등록
+        const formData = toRemarkFormData(note, selectedDate);
+        saved = await createRemark(selectedPetId, formData);
+      }
+
+      setNotes(prev =>
+        addOrUpdateNoteList(prev, {
+          id: saved.remarkId,
+          title: saved.title,
+          content: saved.content,
+        })
+      );
+
+      closeModal();
+    } catch (err) {
+      console.error('특이사항 저장 실패', err);
+    }
   };
 
   const handleDeleteRequest = (id: number) => {
     setDeleteTargetId(id);
   };
 
-  const handleConfirmDelete = () => {
+  const handleConfirmDelete = async () => {
     if (deleteTargetId === null) return;
-    setNotes(prev => deleteNoteById(prev, deleteTargetId));
-    setDeleteTargetId(null);
+
+    try {
+      await deleteRemark(deleteTargetId);
+      setNotes(prev => deleteNoteById(prev, deleteTargetId));
+    } catch (err) {
+      console.error('특이사항 삭제 실패', err);
+    } finally {
+      setDeleteTargetId(null);
+    }
   };
 
   const handleCancelDelete = () => {
     setDeleteTargetId(null);
   };
+
+  const routines = data?.routineResponseList ?? [];
 
   return (
     <Wrapper>

--- a/src/features/calendar/WeeklyDetailsSection.tsx
+++ b/src/features/calendar/WeeklyDetailsSection.tsx
@@ -16,6 +16,7 @@ import type { RootState } from '@/store/store';
 import type { Note } from '@/types/note';
 import { formatDate } from '@/utils/calendar';
 import { toRemarkFormData } from '@/utils/transform/note';
+import { toRoutineModel } from '@/utils/transform/routine';
 
 interface WeeklyDetailsSectionProps {
   selectedDate: Date;
@@ -134,6 +135,8 @@ export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps
     setDeleteTargetId(null);
   };
 
+  const routines = data?.routineResponseList?.map(toRoutineModel) ?? [];
+
   return (
     <Wrapper>
       <Divider />
@@ -144,7 +147,7 @@ export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps
           <SectionAction onClick={handleAddNote}>특이사항 추가</SectionAction>
         </MarginBottom>
 
-        <RoutineItem petId={selectedPetId ?? -1} />
+        <RoutineItem petId={selectedPetId ?? -1} routines={routines} />
         <NoteItemList notes={notes} onEdit={handleEditNote} onDelete={handleDeleteRequest} />
       </MarginTop>
 

--- a/src/features/calendar/WeeklyDetailsSection.tsx
+++ b/src/features/calendar/WeeklyDetailsSection.tsx
@@ -16,7 +16,6 @@ import type { RootState } from '@/store/store';
 import type { Note } from '@/types/note';
 import { formatDate } from '@/utils/calendar';
 import { toRemarkFormData } from '@/utils/transform/note';
-import { toRoutineModel } from '@/utils/transform/routine';
 
 interface WeeklyDetailsSectionProps {
   selectedDate: Date;
@@ -135,8 +134,6 @@ export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps
     setDeleteTargetId(null);
   };
 
-  const routines = data?.routineResponseList?.map(toRoutineModel) ?? [];
-
   return (
     <Wrapper>
       <Divider />
@@ -147,7 +144,7 @@ export const WeeklyDetailsSection = ({ selectedDate }: WeeklyDetailsSectionProps
           <SectionAction onClick={handleAddNote}>특이사항 추가</SectionAction>
         </MarginBottom>
 
-        <RoutineItem petId={selectedPetId ?? -1} routines={routines} />
+        <RoutineItem petId={selectedPetId ?? -1} />
         <NoteItemList notes={notes} onEdit={handleEditNote} onDelete={handleDeleteRequest} />
       </MarginTop>
 

--- a/src/features/calendar/WeeklyViewPanel.tsx
+++ b/src/features/calendar/WeeklyViewPanel.tsx
@@ -1,10 +1,15 @@
+import { useQueries } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
+import { fetchMonthlyEntries } from '@/apis/calendar';
 import { DAYS_OF_WEEK } from '@/constants/calendar';
 import { WeeklyDetailsSection } from '@/features/calendar/WeeklyDetailsSection';
 import { WeekView } from '@/features/calendar/WeekView';
-import { getMonthNumber } from '@/utils/calendar';
+import type { RootState } from '@/store/store';
+import type { CalendarMarkType } from '@/types/calendar';
+import { getMonthNumber, getSurroundingMonths } from '@/utils/calendar';
 
 interface WeeklyViewPanelProps {
   viewDate: Date;
@@ -13,21 +18,56 @@ interface WeeklyViewPanelProps {
   onDateClick: (date: Date) => void;
 }
 
+const isSameWeek = (date1: Date, date2: Date) => {
+  const startOfWeek = (date: Date) => {
+    const d = new Date(date);
+    d.setDate(d.getDate() - d.getDay());
+    return d;
+  };
+  return startOfWeek(date1).toDateString() === startOfWeek(date2).toDateString();
+};
+
 export const WeeklyViewPanel = ({
   viewDate,
   selectedDate,
   onChangeViewDate,
   onDateClick,
 }: WeeklyViewPanelProps) => {
-  const isSameWeek = (date1: Date, date2: Date) => {
-    const startOfWeek = (date: Date) => {
-      const d = new Date(date);
-      d.setDate(d.getDate() - d.getDay());
-      return d;
-    };
-    return startOfWeek(date1).toDateString() === startOfWeek(date2).toDateString();
-  };
+  const selectedPetId = useSelector((state: RootState) => state.selectedPet.id);
 
+  const formattedMonths = getSurroundingMonths(selectedDate); // ['2025-06', '2025-07', '2025-08']
+
+  // ✅ 날짜별 엔트리 조회 (병렬 요청)
+  const results = useQueries({
+    queries: formattedMonths.map(month => ({
+      queryKey: ['monthlyEntries', selectedPetId, month],
+      queryFn: () => fetchMonthlyEntries(selectedPetId ?? -1, month),
+      enabled: !!selectedPetId,
+      staleTime: 1000 * 60 * 5,
+    })),
+  });
+
+  const allEntries = results.flatMap(r => r.data ?? []);
+
+  // ✅ 마킹 정보로 변환
+  const calendarMarks: Record<string, CalendarMarkType[]> = allEntries.reduce(
+    (acc, entry) => {
+      const types: CalendarMarkType[] = [];
+
+      if (entry.completed) types.push('completed');
+      if (entry.memo) types.push('memo');
+      if (entry.remarked) types.push('note'); // 👈 renamed
+
+      if (types.length > 0) {
+        acc[entry.entryDate] = types;
+      }
+
+      return acc;
+    },
+    {} as Record<string, CalendarMarkType[]>
+  );
+
+  // ✅ 월/주차 표기
   const getWeekOfMonth = (date: Date): number => {
     const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
     const dayOfWeek = firstDay.getDay(); // 0: 일요일 ~ 6: 토요일
@@ -35,6 +75,7 @@ export const WeeklyViewPanel = ({
     return Math.ceil(offsetDate / 7);
   };
 
+  // ✅ 이전 주 이동
   const handlePrevWeek = () => {
     const prevWeek = new Date(viewDate);
     prevWeek.setDate(viewDate.getDate() - 7);
@@ -50,6 +91,7 @@ export const WeeklyViewPanel = ({
     }
   };
 
+  // ✅ 다음 주 이동
   const handleNextWeek = () => {
     const nextWeek = new Date(viewDate);
     nextWeek.setDate(viewDate.getDate() + 7);
@@ -83,7 +125,12 @@ export const WeeklyViewPanel = ({
           ))}
         </DayHeaderRow>
 
-        <WeekView viewDate={viewDate} selectedDate={selectedDate} onDateClick={onDateClick} />
+        <WeekView
+          viewDate={viewDate}
+          selectedDate={selectedDate}
+          onDateClick={onDateClick}
+          calendarMarks={calendarMarks}
+        />
       </CalendarMonthWrapper>
 
       <WeeklyDetailsSection selectedDate={selectedDate} />

--- a/src/features/routine/RoutineItem.tsx
+++ b/src/features/routine/RoutineItem.tsx
@@ -14,7 +14,6 @@ import Notice from '@/assets/icons/notice.svg?react';
 
 interface RoutineItemProps {
   petId: number;
-  routines?: Routine[];
 }
 
 interface ModalProps {
@@ -22,7 +21,7 @@ interface ModalProps {
   slotId: SlotId | null;
 }
 
-export const RoutineItem = ({ petId, routines }: RoutineItemProps) => {
+export const RoutineItem = ({ petId }: RoutineItemProps) => {
   const [modal, setModal] = useState<ModalProps>({ open: false, slotId: null });
 
   type StatusType = 'UNCHECKED' | 'note' | 'CHECKED';
@@ -33,11 +32,9 @@ export const RoutineItem = ({ petId, routines }: RoutineItemProps) => {
     CHECKED: <Check width={24} color="#4D9DE0" />,
   } as const;
 
-  const { data: routineDataFromHook } = useDailyRoutine(petId);
+  const { data: routineData } = useDailyRoutine(petId);
 
-  const routineList = routines ?? routineDataFromHook;
-
-  if (!routineList) {
+  if (!routineData) {
     return <NonSlot>슬롯을 설정해주세요</NonSlot>;
   }
 
@@ -53,7 +50,7 @@ export const RoutineItem = ({ petId, routines }: RoutineItemProps) => {
 
   return (
     <div>
-      {routineList.map((rtn: Routine) => {
+      {routineData.map((rtn: Routine) => {
         const { id, Icon, label, unit, placeholder } = SLOT_ITEMS.find(
           slot => slot.id === rtn.category
         )!;

--- a/src/features/routine/RoutineItem.tsx
+++ b/src/features/routine/RoutineItem.tsx
@@ -14,6 +14,7 @@ import Notice from '@/assets/icons/notice.svg?react';
 
 interface RoutineItemProps {
   petId: number;
+  routines?: Routine[];
 }
 
 interface ModalProps {
@@ -21,7 +22,7 @@ interface ModalProps {
   slotId: SlotId | null;
 }
 
-export const RoutineItem = ({ petId }: RoutineItemProps) => {
+export const RoutineItem = ({ petId, routines }: RoutineItemProps) => {
   const [modal, setModal] = useState<ModalProps>({ open: false, slotId: null });
 
   type StatusType = 'UNCHECKED' | 'note' | 'CHECKED';
@@ -32,9 +33,11 @@ export const RoutineItem = ({ petId }: RoutineItemProps) => {
     CHECKED: <Check width={24} color="#4D9DE0" />,
   } as const;
 
-  const { data: routineData } = useDailyRoutine(petId);
+  const { data: routineDataFromHook } = useDailyRoutine(petId);
 
-  if (!routineData) {
+  const routineList = routines ?? routineDataFromHook;
+
+  if (!routineList) {
     return <NonSlot>슬롯을 설정해주세요</NonSlot>;
   }
 
@@ -50,7 +53,7 @@ export const RoutineItem = ({ petId }: RoutineItemProps) => {
 
   return (
     <div>
-      {routineData.map((rtn: Routine) => {
+      {routineList.map((rtn: Routine) => {
         const { id, Icon, label, unit, placeholder } = SLOT_ITEMS.find(
           slot => slot.id === rtn.category
         )!;

--- a/src/pages/AuthLoginRedirectPage.tsx
+++ b/src/pages/AuthLoginRedirectPage.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
+import { IS_DEV } from '@/constants/env';
+
 export const AuthLoginRedirectPage = () => {
   const navigate = useNavigate();
 
@@ -14,7 +16,8 @@ export const AuthLoginRedirectPage = () => {
     }
 
     // 브라우저가 직접 백엔드로 이동하여 302 리디렉션을 따르도록 함
-    window.location.href = `${import.meta.env.VITE_BACKEND_URL}/auth/kakao/login/dev?code=${code}`;
+    const redirectUrl = `${import.meta.env.VITE_BACKEND_URL}/auth/kakao/login${IS_DEV ? '/dev' : ''}?code=${code}`;
+    window.location.href = redirectUrl;
     // const getToken = async () => {
     //   try {
     //     await kakaoLogin(code); // API 호출만 수행

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,26 +1,28 @@
-import { useState } from 'react';
-
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { MonthlyViewPanel } from '@/features/calendar/MonthlyViewPanel';
 import { WeeklyViewPanel } from '@/features/calendar/WeeklyViewPanel';
-import type { CalendarMode } from '@/types/calendar';
+import { setMode, setSelectedDate, setViewDate } from '@/store/calendarSlice';
+import type { RootState } from '@/store/store';
 import { isSameDay } from '@/utils/calendar';
 
 export const CalendarPage = () => {
-  const [mode, setMode] = useState<CalendarMode>('month');
-  const [viewDate, setViewDate] = useState<Date>(new Date());
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const dispatch = useDispatch();
+
+  const mode = useSelector((state: RootState) => state.calendar.mode);
+  const viewDate = useSelector((state: RootState) => state.calendar.viewDate);
+  const selectedDate = useSelector((state: RootState) => state.calendar.selectedDate);
 
   const handleSelectedtDate = (date: Date) => {
     // 주간 보기에서 동일 날짜를 다시 선택하면 월간 모드로 전환
     if (mode === 'week' && isSameDay(selectedDate, date)) {
-      setMode('month');
+      dispatch(setMode('month'));
     } else {
-      setMode('week');
+      dispatch(setMode('week'));
     }
-    setSelectedDate(date);
-    setViewDate(date); // 선택된 날짜 기준으로 viewDate도 갱신
+    dispatch(setSelectedDate(date));
+    dispatch(setViewDate(date)); // 선택된 날짜 기준으로 viewDate 갱신
   };
 
   return (
@@ -31,7 +33,7 @@ export const CalendarPage = () => {
         <MonthlyViewPanel
           viewDate={viewDate}
           selectedDate={selectedDate}
-          onChangeViewDate={setViewDate}
+          onChangeViewDate={date => dispatch(setViewDate(date))}
           onDateClick={handleSelectedtDate}
         />
       )}
@@ -40,7 +42,7 @@ export const CalendarPage = () => {
         <WeeklyViewPanel
           viewDate={viewDate}
           selectedDate={selectedDate}
-          onChangeViewDate={setViewDate}
+          onChangeViewDate={date => dispatch(setViewDate(date))}
           onDateClick={handleSelectedtDate}
         />
       )}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,13 +6,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { getPets } from '@/apis/pets';
+import { getPets, type Pet } from '@/apis/pets';
 import { BriefCard } from '@/features/home/BriefCard';
 import { NameTagBar } from '@/features/home/NameTagBar';
 import { TodayBar } from '@/features/home/TodayBar';
 import { Routine } from '@/features/routine/Routine';
 import { useBriefCardData } from '@/hooks/useBriefCardData';
-import { setSelectedPet } from '@/store/petSlice';
+import { setSelectedPet, type SelectedPetState } from '@/store/petSlice';
 import type { RootState } from '@/store/store';
 import type { PetListType } from '@/types/pets';
 
@@ -29,6 +29,14 @@ interface RemarkProps {
   title: string;
   remarkDate: string;
 }
+
+const convertToSelectedPet = (pet: Pet): SelectedPetState => ({
+  id: pet.id,
+  name: pet.name,
+  species: pet.type, // type → species로 매핑
+  gender: '남아', // 임시 기본값 설정.
+  birthDate: new Date(), // 임시 기본값 설정. 추후 API 응답 수정 필요.
+});
 
 export const HomePage = () => {
   const dispatch = useDispatch();
@@ -47,13 +55,13 @@ export const HomePage = () => {
 
   // redux에서 현재 선택된 petId 가져오기
   const selectedPetId = useSelector((state: RootState) => state.selectedPet.id);
-  const selectedPet = sortedPets.find((pet: PetListType) => pet.id === selectedPetId);
+  const selectedPet = sortedPets.find((pet: Pet) => pet.id === selectedPetId);
 
   // selectedPetId가 대표 동물로 설정
   useEffect(() => {
     if (sortedPets.length > 0 && selectedPetId === null) {
       const firstPet = sortedPets[0];
-      dispatch(setSelectedPet(firstPet));
+      dispatch(setSelectedPet(convertToSelectedPet(firstPet)));
       localStorage.setItem('selectedPetId', String(firstPet.id));
     }
   }, [sortedPets, selectedPetId, dispatch]);
@@ -61,7 +69,7 @@ export const HomePage = () => {
   const handleSelectPet = (id: number) => {
     const pet = sortedPets.find((p: PetListType) => p.id === id);
     if (pet) {
-      dispatch(setSelectedPet(pet));
+      dispatch(setSelectedPet(convertToSelectedPet(pet)));
       localStorage.setItem('selectedPetId', String(pet.id));
     }
   };

--- a/src/store/calendarSlice.ts
+++ b/src/store/calendarSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { CalendarMode } from '@/types/calendar';
+
+interface CalendarState {
+  mode: CalendarMode;
+  viewDate: Date;
+  selectedDate: Date;
+}
+
+const initialState: CalendarState = {
+  mode: 'month',
+  viewDate: new Date(),
+  selectedDate: new Date(),
+};
+
+const calendarSlice = createSlice({
+  name: 'calendar',
+  initialState,
+  reducers: {
+    setMode: (state, action: PayloadAction<CalendarMode>) => {
+      state.mode = action.payload;
+    },
+    setViewDate: (state, action: PayloadAction<Date>) => {
+      state.viewDate = action.payload;
+    },
+    setSelectedDate: (state, action: PayloadAction<Date>) => {
+      state.selectedDate = action.payload;
+    },
+  },
+});
+
+export const { setMode, setViewDate, setSelectedDate } = calendarSlice.actions;
+export default calendarSlice.reducer;

--- a/src/store/petSlice.ts
+++ b/src/store/petSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-interface SelectedPetState {
+export interface SelectedPetState {
   id: number | null;
   name: string;
   species: string;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import authReducer from './authSlice';
+import calendarReducer from './calendarSlice';
 import petReducer from './petSlice';
 import userReducer from './userSlice';
 
@@ -9,6 +10,7 @@ export const store = configureStore({
     auth: authReducer,
     selectedPet: petReducer,
     user: userReducer,
+    calendar: calendarReducer,
   },
 });
 

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -6,6 +6,16 @@ export const formatDate = (date: Date): string => {
 };
 
 /**
+ * Date 객체를 'YYYY-MM' 형식 문자열로 포맷합니다.
+ * 예: new Date(2025, 6, 1) → '2025-07'
+ */
+export const formatYearMonth = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1; // 0-based → 1-based
+  return `${year}-${month.toString().padStart(2, '0')}`;
+};
+
+/**
  * 주어진 날짜에 해당하는 달력용 날짜 배열 반환 (앞/뒤 포함 7xN 구성)
  * @param viewDate - 기준 날짜 (ex: new Date(2025, 6, 1) = 2025년 7월)
  */

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -52,6 +52,26 @@ export const getMonthDates = (viewDate: Date): Date[] => {
 };
 
 /**
+ * 해당 날짜를 기준으로 주간 날짜 배열 반환 (일요일 ~ 토요일)
+ * @param date 기준 날짜
+ * @returns 일주일(7일)의 Date[] 배열
+ */
+export function getWeekDates(date: Date): Date[] {
+  const result: Date[] = [];
+  const dayOfWeek = date.getDay();
+  const sunday = new Date(date);
+  sunday.setDate(date.getDate() - dayOfWeek);
+
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(sunday);
+    d.setDate(sunday.getDate() + i);
+    result.push(d);
+  }
+
+  return result;
+}
+
+/**
  * 두 날짜가 같은 연도와 같은 월인지 확인
  *
  * @param a - 비교할 첫 번째 날짜 객체
@@ -87,4 +107,17 @@ export const getYear = (date: Date): number => {
  */
 export const getMonthNumber = (date: Date): number => {
   return date.getMonth() + 1;
+};
+
+/**
+ * 지정한 날짜를 기준으로 이전/현재/다음 달의 YYYY-MM 문자열 배열을 반환
+ * @example getSurroundingMonths(new Date('2025-08-01'))
+ * // → ['2025-07', '2025-08', '2025-09']
+ */
+export const getSurroundingMonths = (date: Date): string[] => {
+  const prev = new Date(date.getFullYear(), date.getMonth() - 1, 1);
+  const current = new Date(date.getFullYear(), date.getMonth(), 1);
+  const next = new Date(date.getFullYear(), date.getMonth() + 1, 1);
+
+  return [prev, current, next].map(formatYearMonth);
 };

--- a/src/utils/transform/note.ts
+++ b/src/utils/transform/note.ts
@@ -1,0 +1,10 @@
+import type { RemarkFormData } from '@/apis/note';
+import type { Note } from '@/types/note';
+
+import { formatDate } from '../calendar';
+
+export const toRemarkFormData = (note: Note, date: Date): RemarkFormData => ({
+  title: note.title,
+  content: note.content,
+  remarkDate: formatDate(date), // 'YYYY-MM-DD'
+});

--- a/src/utils/transform/routine.ts
+++ b/src/utils/transform/routine.ts
@@ -1,0 +1,20 @@
+import type { Routine as APIRoutine } from '@/apis/calendar';
+import type { RoutineStatus, SlotId, Routine as UiRoutine } from '@/types/routine';
+
+export const toRoutineModel = (routine: APIRoutine): UiRoutine => {
+  const statusMap: Record<APIRoutine['status'], RoutineStatus> = {
+    CHECKED: 'CHECKED',
+    MEMO: 'note',
+    UNCHECKED: 'UNCHECKED',
+  };
+
+  return {
+    id: routine.category as SlotId, // SLOT_ITEMS에서 유효한 값인지 보장 필요
+    category: routine.category,
+    status: statusMap[routine.status],
+    targetAmount: routine.targetAmount ?? '',
+    actualAmount: routine.actualAmount,
+    content: routine.content,
+    date: routine.date,
+  };
+};


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 주간 달력에서 특이사항 API 연동 및 달력 마커 상태를 전역에서 관리하도록 개선

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #47 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- `getSurroundingMonths` 유틸 함수로 이전/현재/다음 달에 대한 마커 데이터를 한 번에 조회 (월간/주간 공통)
- `/api/entries/{petId}/daily/{date}` 엔드포인트와 연동하여 루틴 및 특이사항 데이터 조회
- 기존 `props drilling`을 제거하고 전역 상태에서 달력 마커 상태 관리

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [x] 주간 달력에서 특이사항 존재 시 마커 정상 표시됨
- [x] 특이사항 없는 경우 마커 미표시 확인
- [x] 월간/주간 화면 간 데이터 충돌 없음

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
- 홈 화면에서 사용하는 `RoutineItem` 컴포넌트를 재활용하면서 발생하는 중복 fetch는 따로 처리하지 않았습니다. 대신, optional chaining (`?.`)을 통해 props로 전달되는 값의 충돌을 예방하고 fallback 처리를 해두었습니다.
- `/types/pet`의 `PetListType`, `/apis/pet`의 `Pet`, `/utils/transform/routine` 등 API 응답과 프론트엔드에서 사용하는 타입이 서로 다른 경우가 많은데, 추후 통합하는 방식을 일관되게 정하면 좋을 것 같습니다.
