### PR TITLE
chore: 디자인 시스템 1단계 적용 - color/typography 토큰화 및 런타임 변수 주입 (KB3-128)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pet Fit</title>
+
+    <link
+      rel="preload"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css"
+      as="style"
+      onload="this.onload=null;this.rel='stylesheet'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css"
+      />
+    </noscript>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,13 @@ import { useEffect } from 'react';
 
 import { useDispatch } from 'react-redux';
 import { RouterProvider } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
 
 import { router } from './routes/Router';
 import { setSelectedPetId } from './store/petSlice';
 import { setMemberId } from './store/userSlice';
+import { ColorVars } from './styles/ColorVars';
+import { theme } from './styles/theme';
 
 const AppInitializer = () => {
   const dispatch = useDispatch();
@@ -27,10 +30,11 @@ const AppInitializer = () => {
 
 const App = () => {
   return (
-    <>
+    <ThemeProvider theme={theme}>
+      <ColorVars />
       <AppInitializer />
       <RouterProvider router={router} />
-    </>
+    </ThemeProvider>
   );
 };
 

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -85,7 +85,6 @@ export const verifyAuth = async (): Promise<boolean> => {
   return res.data.content;
 };
 
-
 export const getNickname = async (memberId: number | null) => {
   try {
     const response = await axiosInstance.get(`members/${memberId}`);

--- a/src/components/CustomDatePicker.tsx
+++ b/src/components/CustomDatePicker.tsx
@@ -4,6 +4,7 @@ import { Calendar, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import styled from 'styled-components';
 
 import { DAYS_OF_WEEK } from '@/constants/calendar';
+import { typo } from '@/styles/tokens';
 import type { BaseFieldProps } from '@/types/form';
 import {
   formatDate,
@@ -67,14 +68,14 @@ export const CustomDatePicker = ({
     <FieldGroup>
       {label && <Label>{label}</Label>}
       <TriggerButton onClick={handleToggleCalendar}>
-        <span>{formatDate(selectedDate)}</span>
-        <Calendar size={18} />
+        <TriggerSpan>{formatDate(selectedDate)}</TriggerSpan>
+        <Calendar size={18} color="var(--grey-700)" />
       </TriggerButton>
       {isCalendarOpen && (
         <CalendarPanel>
           <CalendarHeaderRow>
             <button onClick={handlePrevMonth}>
-              <ChevronLeft size={18} />
+              <ChevronLeft size={18} color="var(--grey-700)" />
             </button>
             <CalendarHeaderCenter>
               <span>
@@ -82,12 +83,12 @@ export const CustomDatePicker = ({
               </span>
               {withYearSelect && (
                 <YearToggleButton onClick={handleToggleYearSelect}>
-                  <ChevronDown size={18} />
+                  <ChevronDown size={18} color="var(--grey-700)" />
                 </YearToggleButton>
               )}
             </CalendarHeaderCenter>
             <button onClick={handleNextMonth}>
-              <ChevronRight size={18} />
+              <ChevronRight size={18} color="var(--grey-700)" />
             </button>
           </CalendarHeaderRow>
 
@@ -150,26 +151,31 @@ const FieldGroup = styled.div`
 
 const Label = styled.label`
   padding-left: 8px;
-  font-size: 14px;
-  color: #333;
+  color: var(--grey-600);
+  ${typo.bodyReg14};
 `;
 
 const TriggerButton = styled.div`
-  padding: 12px 16px;
-  background-color: #fff8e7;
-  border: 1.5px solid #facc15;
-  border-radius: 8px;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 12px 16px;
+  background-color: var(--main-100);
+  border: 1.5px solid var(--main-500);
+  border-radius: 8px;
   cursor: pointer;
+`;
+
+const TriggerSpan = styled.span`
+  color: var(--grey-700);
+  ${typo.bodySemi14};
 `;
 
 const CalendarPanel = styled.div`
   margin-top: -4px;
   padding: 16px;
-  background-color: #fff8e7;
-  border: 1.5px solid #facc15;
+  background-color: var(--main-100);
+  border: 1.5px solid var(--main-500);
   border-radius: 8px;
 `;
 
@@ -177,7 +183,6 @@ const CalendarHeaderRow = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-weight: bold;
   margin-bottom: 10px;
 `;
 
@@ -185,17 +190,12 @@ const CalendarHeaderCenter = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+  ${typo.bodySemi14};
 `;
 
 const YearToggleButton = styled.button`
   background: transparent;
-  border: none;
   padding: 0;
-  cursor: pointer;
-
-  svg {
-    stroke: #333;
-  }
 `;
 
 const YearScrollContainer = styled.div`
@@ -213,8 +213,8 @@ const CalendarHeaderCell = styled.div`
   justify-content: center;
   align-items: center;
   min-height: 48px;
-  font-weight: bold;
-  color: #373737;
+  color: var(--grey-700);
+  ${typo.bodyMed16};
 `;
 
 const DayOfWeekRow = styled.div`
@@ -225,7 +225,7 @@ const DayOfWeekRow = styled.div`
 const CalendarGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  border: 1px solid #fff;
+  border: 1px solid var(--white-0);
 `;
 
 const DateCell = styled.div<{
@@ -238,10 +238,10 @@ const DateCell = styled.div<{
   align-items: center;
   min-height: 48px;
   font-weight: normal;
-  color: ${({ $dimmed }) => ($dimmed ? '#ccc' : '#000')};
+  color: ${({ $dimmed }) => ($dimmed ? 'var(--grey-300)' : '#000')};
   background-color: ${({ $dimmed, $isSelected }) =>
-    $isSelected ? '#FFE299' : $dimmed ? '#fff' : 'transparent'};
-  border: 2px solid #fff;
+    $isSelected ? 'var(--main-300)' : $dimmed ? 'var(--white-0)' : 'transparent'};
+  border: 2px solid var(--white-0);
   cursor: pointer;
 
   &:hover {

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import styled from 'styled-components';
 
+import { typo } from '@/styles/tokens';
 import type { BaseFieldProps } from '@/types/form';
 
 interface CustomSelectProps extends BaseFieldProps {
@@ -23,8 +24,8 @@ export const CustomSelect = ({ label, value, onChange, options }: CustomSelectPr
     <FieldGroup>
       {label && <Label>{label}</Label>}
       <SelectTrigger onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
-        <span>{value}</span>
-        <ChevronDown size={18} />
+        <SelectSpan>{value}</SelectSpan>
+        <ChevronDown size={18} color="var(--grey-700)" />
       </SelectTrigger>
       {isDropdownOpen && (
         <SelectDropdown>
@@ -47,8 +48,8 @@ const FieldGroup = styled.div`
 
 const Label = styled.label`
   padding-left: 8px;
-  font-size: 14px;
-  color: #333;
+  color: var(--grey-600);
+  ${typo.bodyReg14};
 `;
 
 const SelectTrigger = styled.div`
@@ -56,10 +57,15 @@ const SelectTrigger = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  background-color: #fff8e7;
-  border: 1.5px solid #facc15;
+  background-color: var(--main-100);
+  border: 1.5px solid var(--main-500);
   border-radius: 8px;
   cursor: pointer;
+`;
+
+const SelectSpan = styled.span`
+  color: var(--grey-700);
+  ${typo.bodySemi14};
 `;
 
 const SelectDropdown = styled.ul`
@@ -68,15 +74,13 @@ const SelectDropdown = styled.ul`
   gap: 10px;
   margin-top: -4px;
   padding: 10px 20px;
-  background-color: #fff8e7;
-  border: 1.5px solid #facc15;
+  background-color: var(--main-100);
+  border: 1.5px solid var(--main-500);
   border-radius: 8px;
 `;
 
 const SelectOption = styled.li`
-  color: #666666;
+  color: var(--grey-500);
+  ${typo.bodySemi14};
   cursor: pointer;
-  &:hover {
-    background-color: #fef3c7;
-  }
 `;

--- a/src/components/common/ConfirmDeleteModal.tsx
+++ b/src/components/common/ConfirmDeleteModal.tsx
@@ -59,7 +59,6 @@ const DeleteButton = styled.button`
   padding: 8px 0;
   color: #f0f0f0;
   background: #ff5c33;
-  border: none;
   border-radius: 8px;
   font-size: 14px;
   font-weight: 600;

--- a/src/components/common/FormInput.tsx
+++ b/src/components/common/FormInput.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
+import { typo } from '@/styles/tokens';
 import type { BaseFieldProps } from '@/types/form';
 import { MAX_LENGTH, validators, type ValidationType } from '@/utils/validators';
 
@@ -68,17 +69,17 @@ const FieldGroup = styled.div`
 
 const Label = styled.label<{ $hasError?: boolean }>`
   padding-left: 8px;
-  font-size: 14px;
-  color: ${({ $hasError }) => ($hasError ? '#f87171' : '#333')};
+  color: ${({ $hasError }) => ($hasError ? 'var(--warning-500)' : 'var(--grey-600)')};
+  ${typo.bodyReg14};
 `;
 
 const StyledInput = styled.input<{ $hasError?: boolean }>`
   width: 100%;
   padding: 12px 20px;
-  font-size: 16px;
-  background-color: #fff8e7;
-  border: 1.5px solid ${({ $hasError }) => ($hasError ? '#f87171' : '#facc15')};
+  background-color: var(--main-100);
+  border: 1.5px solid ${({ $hasError }) => ($hasError ? 'var(--warning-500)' : 'var(--main-500)')};
   border-radius: 8px;
+  ${({ $hasError }) => ($hasError ? typo.bodySemi14 : typo.bodyReg14)};
 `;
 
 const HelperRow = styled.div`
@@ -89,12 +90,12 @@ const HelperRow = styled.div`
 `;
 
 const CharCount = styled.span<{ $hasError?: boolean }>`
-  font-size: 12px;
-  color: ${({ $hasError }) => ($hasError ? '#f87171' : '#999')};
+  color: ${({ $hasError }) => ($hasError ? 'var(--warning-500)' : 'var(--grey-400)')};
+  ${typo.captionMed12};
 `;
 
 const ErrorMessage = styled.p<{ $isVisible?: boolean }>`
-  color: #f87171;
-  font-size: 12px;
+  color: var(--warning-500);
+  ${typo.captionMed12};
   visibility: ${({ $isVisible }) => ($isVisible ? 'visible' : 'hidden')};
 `;

--- a/src/components/common/FormTextarea.tsx
+++ b/src/components/common/FormTextarea.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
+import { typo } from '@/styles/tokens';
 import type { BaseFieldProps } from '@/types/form';
 import { MAX_LENGTH, validators, type ValidationType } from '@/utils/validators';
 
@@ -68,18 +69,18 @@ const FieldGroup = styled.div`
 
 const Label = styled.label<{ $hasError?: boolean }>`
   padding-left: 8px;
-  font-size: 14px;
-  color: ${({ $hasError }) => ($hasError ? '#f87171' : '#333')};
+  color: ${({ $hasError }) => ($hasError ? 'var(--warning-500)' : 'var(--grey-600)')};
+  ${typo.bodyReg14};
 `;
 
 const StyledTextarea = styled.textarea<{ $hasError?: boolean }>`
   width: 100%;
   height: 100px;
   padding: 12px 20px;
-  font-size: 16px;
-  background-color: #fff8e7;
-  border: 1.5px solid ${({ $hasError }) => ($hasError ? '#f87171' : '#facc15')};
+  background-color: var(--main-100);
+  border: 1.5px solid ${({ $hasError }) => ($hasError ? 'var(--warning-500)' : 'var(--main-500)')};
   border-radius: 16px;
+  ${typo.bodySemi14};
   resize: none;
 `;
 
@@ -91,12 +92,12 @@ const HelperRow = styled.div`
 `;
 
 const CharCount = styled.span<{ $hasError?: boolean }>`
-  font-size: 12px;
-  color: ${({ $hasError }) => ($hasError ? '#f87171' : '#999')};
+  ${typo.captionMed12};
+  color: ${({ $hasError }) => ($hasError ? 'var(--warning-500)' : 'var(--grey-400)')};
 `;
 
 const ErrorMessage = styled.p<{ $isVisible?: boolean }>`
-  color: #f87171;
-  font-size: 12px;
+  color: var(--warning-500);
+  ${typo.captionMed12};
   visibility: ${({ $isVisible }) => ($isVisible ? 'visible' : 'hidden')};
 `;

--- a/src/components/common/MoreActionDropdown.tsx
+++ b/src/components/common/MoreActionDropdown.tsx
@@ -46,10 +46,7 @@ const Wrapper = styled.div`
 `;
 
 const ToggleButton = styled.button`
-  background: none;
-  border: none;
   padding: 4px;
-  cursor: pointer;
 `;
 
 const Dropdown = styled.ul`

--- a/src/components/common/TitleHeader.tsx
+++ b/src/components/common/TitleHeader.tsx
@@ -73,7 +73,6 @@ const Right = styled(SlotBox)`
 
 const IconButton = styled.button`
   all: unset;
-  cursor: pointer;
   display: flex;
   align-items: center;
 `;

--- a/src/features/alarm/ScheduleRegisterModal.tsx
+++ b/src/features/alarm/ScheduleRegisterModal.tsx
@@ -113,8 +113,6 @@ const CloseButton = styled.button`
   top: 0;
   right: 0;
   background: transparent;
-  border: none;
-  cursor: pointer;
 
   svg {
     stroke: #333;
@@ -132,7 +130,6 @@ const SubmitButton = styled.button<{ $disabled: boolean }>`
   font-size: 16px;
   font-weight: 600;
   border-radius: 8px;
-  border: none;
   background-color: ${({ disabled }) => (disabled ? '#eee' : '#facc15')};
   color: ${({ disabled }) => (disabled ? '#999' : '#222')};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};

--- a/src/features/calendar/MonthlyViewPanel.tsx
+++ b/src/features/calendar/MonthlyViewPanel.tsx
@@ -164,9 +164,6 @@ const PetTab = styled.button<{ $active: boolean }>`
   align-items: center;
   gap: 4px;
   padding: 6px;
-  border: none;
-  background: none;
-  cursor: pointer;
   color: ${({ $active }) => ($active ? '#000' : '#888')};
   font-weight: ${({ $active }) => ($active ? 'bold' : 'normal')};
 `;

--- a/src/features/calendar/NoteModal.tsx
+++ b/src/features/calendar/NoteModal.tsx
@@ -110,7 +110,6 @@ const SaveButton = styled.button<{ $disabled: boolean }>`
   padding: 12px 0;
   background-color: ${({ $disabled }) => ($disabled ? '#eee' : '#facc15')};
   border-radius: 10px;
-  border: none;
   color: ${({ $disabled }) => ($disabled ? '#999' : '#222')};
   font-size: 16px;
   font-weight: bold;

--- a/src/features/calendar/WeeklyDetailsSection.tsx
+++ b/src/features/calendar/WeeklyDetailsSection.tsx
@@ -198,5 +198,4 @@ const SectionAction = styled.button`
   font-size: 14px;
   color: #757575;
   text-decoration: none;
-  cursor: pointer;
 `;

--- a/src/features/home/BriefCard.tsx
+++ b/src/features/home/BriefCard.tsx
@@ -4,6 +4,8 @@ import { ChevronDown, ChevronUp, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { typo } from '@/styles/tokens';
+
 interface BriefCardItem {
   id: number;
   title: string;
@@ -19,13 +21,17 @@ interface BriefCardProps {
   error?: string | null;
 }
 
+const COLLAPSED_COUNT = 2;
+
+const shouldShowToggle = (len: number) => len > COLLAPSED_COUNT;
+
 export const BriefCard = ({ label, color, items, loading, error }: BriefCardProps) => {
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
 
   const hasContent = items.length > 0;
-  const showAccordion = items.length >= 3; // 2개 이상부터 토글 표시
-  const visibleItems = expanded ? items : items.slice(0, 2);
+  const showAccordion = shouldShowToggle(items.length);
+  const visibleItems = expanded ? items : items.slice(0, COLLAPSED_COUNT);
 
   const handleAddClick = () => {
     if (label === '일정') navigate('/alarm');
@@ -38,7 +44,7 @@ export const BriefCard = ({ label, color, items, loading, error }: BriefCardProp
         <ColorBar style={{ backgroundColor: color }} />
         <Title>{label}</Title>
         <AddButton type="button" onClick={handleAddClick} aria-label={`${label} 추가`}>
-          <Plus size={20} color="#999" />
+          <Plus size={20} color="var(--grey-700)" />
         </AddButton>
       </Header>
       <Content>
@@ -94,17 +100,12 @@ const ColorBar = styled.div`
 
 const Title = styled.span`
   flex: 1;
-  font-size: 16px;
-  font-weight: 500;
-  letter-spacing: -0.4px;
+  ${typo.bodyMed16};
 `;
 
 const AddButton = styled.button`
   font-size: 20px;
-  color: #999;
-  background: none;
-  border: none;
-  cursor: pointer;
+  color: var(--grey-700);
 `;
 
 const Content = styled.div`
@@ -114,13 +115,13 @@ const Content = styled.div`
 `;
 
 const ErrorMessage = styled.div`
-  font-size: 14px;
-  color: #d32f2f;
+  color: var(--warning-500);
+  ${typo.bodyReg14};
 `;
 
 const LoadingMessage = styled.div`
-  font-size: 14px;
   color: #888;
+  ${typo.bodyReg14};
 `;
 
 const Item = styled.div`
@@ -140,9 +141,7 @@ const ToggleButton = styled.button`
   justify-content: center;
   width: 28px;
   height: 24px;
-  border: none;
   background: transparent;
-  cursor: pointer;
   border-radius: 6px;
 
   &:hover {

--- a/src/features/routine/RoutineDetailModal.tsx
+++ b/src/features/routine/RoutineDetailModal.tsx
@@ -119,9 +119,6 @@ const Header = styled.div`
 
 const Close = styled.button`
   font-size: 20px;
-  background: none;
-  border: none;
-  cursor: pointer;
 `;
 
 const Content = styled.div`

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,8 @@
 @import './styles/reset.css';
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  font-family: "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, "Noto Sans KR", sans-serif;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/src/pages/AddPetPage.tsx
+++ b/src/pages/AddPetPage.tsx
@@ -66,8 +66,6 @@ const NextButton = styled.button<{ disabled?: boolean }>`
   padding: 16px 0;
   font-size: 16px;
   background-color: ${({ disabled }) => (disabled ? '#ccc' : '#facc15')};
-  color: #000;
-  border: none;
   border-radius: 12px;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;

--- a/src/pages/AlarmPage.tsx
+++ b/src/pages/AlarmPage.tsx
@@ -201,7 +201,6 @@ const AddButton = styled.button<{ hasList?: boolean }>`
   padding: 8px 12px;
   background-color: #facc15;
   color: #222;
-  border: none;
   border-radius: 8px;
   font-size: 14px;
   font-weight: 600;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import { Routine } from '@/features/routine/Routine';
 import { useBriefCardData } from '@/hooks/useBriefCardData';
 import { setSelectedPet, type SelectedPetState } from '@/store/petSlice';
 import type { RootState } from '@/store/store';
+import { typo } from '@/styles/tokens';
 import type { PetListType } from '@/types/pets';
 
 import Logo from '@/assets/icons/logo.svg?react';
@@ -95,7 +96,7 @@ export const HomePage = () => {
             <CardRow>
               <BriefCard
                 label="일정"
-                color="#4D9DE0"
+                color="var(--point-500)"
                 items={scheduleData.map((s: ScheduleProps) => ({
                   id: s.scheduleId,
                   title: s.title,
@@ -104,7 +105,7 @@ export const HomePage = () => {
               />
               <BriefCard
                 label="특이사항"
-                color="#FF5C33"
+                color="var(--warning-500)"
                 items={remarkData.map((r: RemarkProps) => ({
                   id: r.remarkId,
                   title: r.title,
@@ -152,8 +153,7 @@ const BriefingSection = styled.div`
 `;
 
 const SectionTitle = styled.h2`
-  font-size: 18px;
-  font-weight: bold;
+  ${typo.titleSemi18};
 `;
 
 const CardRow = styled.div`

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import kakaoLoginButton from '@/assets/images/kakao_login_medium_wide.png';
+import { typo } from '@/styles/tokens';
 
 import Logo from '@/assets/icons/logo.svg?react';
 
@@ -31,23 +32,17 @@ const Container = styled.div`
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background-color: white;
+  background-color: var(--color-white-0);
   gap: 30px;
 `;
 
 const Description = styled.p`
   text-align: center;
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 1.5;
-  color: #333;
+  ${typo.bodyMed18};
 `;
 
 const KakaoButton = styled.button`
   padding: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
 
   img {
     width: 250px;

--- a/src/pages/NicknameEditPage.tsx
+++ b/src/pages/NicknameEditPage.tsx
@@ -72,10 +72,7 @@ export const NicknameEditPage = () => {
 const SaveButton = styled.button`
   white-space: nowrap;
   font-size: 14px;
-  background: none;
-  border: none;
   padding: 0;
-  cursor: pointer;
 
   &:disabled {
     color: #ccc;

--- a/src/pages/SignupPetRegisterPage.tsx
+++ b/src/pages/SignupPetRegisterPage.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { PetRegisterForm } from '@/components/PetRegisterForm';
 import { useRegisterPet } from '@/hooks/useRegisterPet';
 import { setSelectedPet, setSelectedPetId } from '@/store/petSlice';
+import { typo } from '@/styles/tokens';
 import type { PetForm } from '@/types/form';
 
 export const SignupPetRegisterPage = () => {
@@ -59,25 +60,32 @@ const Container = styled.div`
 `;
 
 const Title = styled.h2`
-  text-align: center;
   padding: 18px 0;
-  font-size: 18px;
+  text-align: center;
+  color: var(--grey-700);
+  ${typo.titleSemi18};
 `;
 
 const ErrorMessage = styled.p`
-  color: red;
-  font-size: 14px;
   margin: 8px 0;
   text-align: center;
+  color: var(--warning-500);
+  ${typo.bodyReg14};
 `;
 
-const NextButton = styled.button<{ disabled?: boolean }>`
+const NextButton = styled.button`
   margin-bottom: 24px;
   padding: 16px 0;
-  font-size: 16px;
-  background-color: ${({ disabled }) => (disabled ? '#ccc' : '#facc15')};
-  color: #000;
-  border: none;
   border-radius: 12px;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  ${typo.titleSemi18};
+
+  background: var(--main-500);
+  color: var(--grey-700);
+
+  &:disabled {
+    background: var(--grey-100);
+    color: var(--grey-400);
+    border: 1px solid var(--grey-300);
+    cursor: not-allowed;
+  }
 `;

--- a/src/styles/ColorVars.ts
+++ b/src/styles/ColorVars.ts
@@ -1,0 +1,22 @@
+// src/styles/ColorVars.tsx
+import { createGlobalStyle } from 'styled-components';
+
+import type { AppTheme } from '@/styles/theme';
+
+const buildColorVars = (t: AppTheme) => {
+  const lines: string[] = [];
+  (Object.keys(t.colors) as Array<keyof AppTheme['colors']>).forEach(group => {
+    (Object.keys(t.colors[group]) as Array<keyof AppTheme['colors'][typeof group]>).forEach(
+      shade => {
+        lines.push(`--${String(group)}-${String(shade)}: ${t.colors[group][shade]};`);
+      }
+    );
+  });
+  return lines.join('\n');
+};
+
+export const ColorVars = createGlobalStyle`
+  :root {
+    ${({ theme }) => buildColorVars(theme as AppTheme)}
+  }
+`;

--- a/src/styles/color-vars.declare.css
+++ b/src/styles/color-vars.declare.css
@@ -1,0 +1,54 @@
+/* src/styles/color-vars.declare.css */
+/* DEV-ONLY: 에디터 인텔리센스/오타 방지용 선언.
+   ColorVars(createGlobalStyle)에서 주입하는 변수 이름과 1:1로 맞춘다. */
+
+:root {
+  /* Palette */
+  --main-100: #FFF8E5;
+  --main-200: #FFF1CC;
+  --main-300: #FFE299;
+  --main-400: #FFD56B;
+  --main-500: #FFC533;
+  --main-600: #FFB700;
+  --main-700: #B28000;
+  --main-800: #996E00;
+  --main-900: #805B00;
+
+  --sub-500: #A7E9C3;
+
+  --point-500: #4D9DE0;
+
+  --grey-100: #F0F0F0;
+  --grey-200: #E8E8E8;
+  --grey-300: #DDDDDD;
+  --grey-400: #A5A5A5;
+  --grey-500: #666666;
+  --grey-600: #4D4D4D;
+  --grey-700: #373737;
+  --grey-800: #2E2E2E;
+  --grey-900: #191919;
+
+  --white-0: #FFFFFF;
+  --white-100: #FFFDF8;
+  --white-200: #FDF6EC;
+
+  --black-0: #000000;
+
+  --warning-500: #FF5C33;
+
+  /* Semantic aliases (필요 시 확장) */
+  /* --color-text-primary: var(--color-grey-900);
+  --color-text-secondary: var(--color-grey-700);
+  --color-text-inverse: var(--color-white-0);
+
+  --color-bg-surface: var(--color-white-0);
+  --color-bg-muted: var(--color-grey-100);
+
+  --color-border-default: var(--color-grey-300);
+
+  --color-action-primary: var(--color-main-500);
+  --color-action-primary-hover: var(--color-main-600);
+  --color-action-disabled: var(--color-grey-300);
+
+  --color-status-warning: var(--color-warning-500); */
+}

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -1,0 +1,7 @@
+import 'styled-components';
+import type { AppTheme } from './theme';
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface DefaultTheme extends AppTheme {}
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,114 @@
+// theme.ts
+export const theme = {
+  colors: {
+    main: {
+      100: '#FFF8E5',
+      200: '#FFF1CC',
+      300: '#FFE299',
+      400: '#FFD56B',
+      500: '#FFC533',
+      600: '#FFB700',
+      700: '#B28000',
+      800: '#996E00',
+      900: '#805B00',
+    },
+    sub: {
+      500: '#A7E9C3',
+    },
+    point: {
+      500: '#4D9DE0',
+    },
+    grey: {
+      100: '#F0F0F0',
+      200: '#E8E8E8',
+      300: '#DDDDDD',
+      400: '#A5A5A5',
+      500: '#666666',
+      600: '#4D4D4D',
+      700: '#373737',
+      800: '#2E2E2E',
+      900: '#191919',
+    },
+    white: {
+      0: '#FFFFFF',
+      100: '#FFFDF8',
+      200: '#FDF6EC',
+    },
+    black: {
+      0: '#000000',
+    },
+    warning: {
+      500: '#FF5C33',
+    },
+  },
+
+  typography: {
+    // Title
+    titleBold22: {
+      fontSize: '22px',
+      lineHeight: '32px',
+      fontWeight: 700,
+      letterSpacing: '-0.025em',
+    },
+    titleSemi18: {
+      fontSize: '18px',
+      lineHeight: '24px',
+      fontWeight: 600,
+      letterSpacing: '-0.025em',
+    },
+    titleSemi14: {
+      fontSize: '14px',
+      lineHeight: '20px',
+      fontWeight: 600,
+      letterSpacing: '-0.025em',
+    },
+
+    // Body / Semibold
+    bodySemi14: {
+      fontSize: '14px',
+      lineHeight: '20px',
+      fontWeight: 600,
+      letterSpacing: '-0.025em',
+    },
+    bodySemi13: {
+      fontSize: '13px',
+      lineHeight: '20px',
+      fontWeight: 600,
+      letterSpacing: '-0.025em',
+    },
+
+    // Body / Medium
+    bodyMed18: { fontSize: '18px', lineHeight: '24px', fontWeight: 500, letterSpacing: '-0.025em' },
+    bodyMed16: { fontSize: '16px', lineHeight: '24px', fontWeight: 500, letterSpacing: '-0.025em' },
+    bodyMed13: { fontSize: '13px', lineHeight: '20px', fontWeight: 500, letterSpacing: '-0.025em' },
+
+    // Body / Regular
+    bodyReg18: { fontSize: '18px', lineHeight: '27px', fontWeight: 400, letterSpacing: '-0.025em' },
+    bodyReg14: { fontSize: '14px', lineHeight: '20px', fontWeight: 400, letterSpacing: '-0.025em' },
+
+    // Caption
+    captionMed12: {
+      fontSize: '12px',
+      lineHeight: '18px',
+      fontWeight: 500,
+      letterSpacing: '-0.025em',
+    },
+    captionBold11: {
+      fontSize: '11px',
+      lineHeight: '16px',
+      fontWeight: 700,
+      letterSpacing: '-0.025em',
+    },
+  },
+
+  // spacing scale (추천)
+  space: [0, 2, 4, 8, 12, 16, 24, 32, 48, 64],
+
+  radius: {},
+
+  shadow: {},
+
+  breakpoint: {},
+} as const;
+
+export type AppTheme = typeof theme;

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,0 +1,55 @@
+// src/styles/tokens.ts
+import { css, type DefaultTheme } from 'styled-components';
+
+import type { AppTheme } from '@/styles/theme';
+import { theme } from '@/styles/theme';
+
+/* ───────────── Typography mixins ───────────── */
+type TypoKey = keyof AppTheme['typography'];
+
+export const typo = Object.fromEntries(
+  (Object.keys(theme.typography) as TypoKey[]).map(k => [
+    k,
+    ({ theme }: { theme: DefaultTheme }) => css`
+      font-size: ${theme.typography[k].fontSize};
+      line-height: ${theme.typography[k].lineHeight};
+      font-weight: ${theme.typography[k].fontWeight};
+      letter-spacing: ${theme.typography[k].letterSpacing};
+    `,
+  ])
+) as Record<TypoKey, ({ theme }: { theme: DefaultTheme }) => ReturnType<typeof css>>;
+
+/* ───────────── Color getters (tone) ───────────── */
+type ColorGroups = AppTheme['colors'];
+type GroupKey = keyof ColorGroups;
+type ShadeKeys<G extends GroupKey> = keyof ColorGroups[G] & (string | number);
+
+/** 최종 키: 'white0' | 'grey700' | 'main500' … */
+export type ColorKey = {
+  [G in GroupKey]: `${Extract<G, string>}${Extract<ShadeKeys<G>, string>}`;
+}[GroupKey];
+
+/** 색 값을 string으로 안전하게 좁히는 보조 함수 */
+function pickColor<G extends GroupKey, S extends ShadeKeys<G>>(
+  t: DefaultTheme,
+  g: G,
+  s: S
+): string {
+  // AppTheme 상 색상 값은 문자열 리터럴이므로 string으로 안전 단언
+  return t.colors[g][s] as string;
+}
+
+type ColorGetter = (theme: DefaultTheme) => string;
+
+const toneEntries: Array<[ColorKey, ColorGetter]> = [];
+
+(Object.keys(theme.colors) as GroupKey[]).forEach(<G extends GroupKey>(group: G) => {
+  (Object.keys(theme.colors[group]) as ShadeKeys<G>[]).forEach(
+    <S extends ShadeKeys<G>>(shade: S) => {
+      const key = `${String(group)}${String(shade)}` as ColorKey;
+      toneEntries.push([key, t => pickColor(t, group, shade)]);
+    }
+  );
+});
+
+export const tone = Object.fromEntries(toneEntries) as Record<ColorKey, ColorGetter>;


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 디자인 시스템 1단계로 타이포그래피/컬러 토큰을 도입하고, 색상은 CSS 변수(var) 로 런타임 주입하도록 리팩토링
- 기존 하드코딩(hex)과 개별 스타일을 토큰 기반으로 치환

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #66 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- Typography 토큰/믹스인 추가 (titleBold22, titleSemi18, …)
- Color 팔레트 → CSS 변수 전환
  - ColorVars(createGlobalStyle)로 --color-*-* 변수를 런타임 주입
  - 컴포넌트에서 var(--color-*-*)로 참조(예: background: var(--color-main-500))
- Pretendard CDN 로드 및 :root 폰트 스택 정리

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [ ] ColorVars 주입 후 전역에서 var(--color-*-*) 정상 해석됨
- [ ] BriefCard 색상 prop에 var(--color-warning-500) 전달 시 표시 정상
- [ ] Pretendard 로드 및 폰트 렌더링 이슈 없음(FOUC 미발생)

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
후속 작업 계획
- 세맨틱 컬러 변수(--color-text-primary, --color-action-primary 등) 레이어 추가
- 남은 컴포넌트 단계적 토큰 치환