### PR TITLE
fix: 설정된 슬롯이 없을 때 루틴을 호출하면 에러 발생 (KB3-129)

### DIFF
--- a/src/apis/slot.ts
+++ b/src/apis/slot.ts
@@ -1,13 +1,20 @@
+import axios from 'axios';
+
 import type { SlotType } from '@/types/slot';
 
 import { axiosInstance } from './axiosInstance';
 
-export const getSlot = async (petId: number): Promise<SlotType> => {
+export const getSlot = async (petId: number): Promise<SlotType | null> => {
   try {
-    const response = await axiosInstance.get(`slots/${petId}`);
-    return response.data.content;
+    const response = await axiosInstance.get(`slots/${petId}`, {
+      validateStatus: s => (s >= 200 && s < 300) || s === 404,
+    });
+    return response.status === 404 ? null : response.data.content;
   } catch (error) {
-    console.error('slot 조회 failed: ', error);
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      throw error;
+    }
+    console.error('slot 조회 failed:', error);
     throw error;
   }
 };

--- a/src/features/routine/Routine.tsx
+++ b/src/features/routine/Routine.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { RoutineItem } from '@/features/routine/RoutineItem';
 import { useDailyRoutine } from '@/hooks/useDailyRoutine';
+import { useSlot } from '@/hooks/useSlot';
 
 import { RoutineProgress } from './RoutineProgress';
 
@@ -13,15 +14,21 @@ interface RoutineProps {
 
 export const Routine = ({ petId }: RoutineProps) => {
   const navigate = useNavigate();
-  const { data: routineData } = useDailyRoutine(petId);
+  const { data: slot } = useSlot(petId);
+  const { data: routineData } = useDailyRoutine(petId, {
+    enabled: !!slot,
+  });
 
   return (
     <Container>
       <RoutineTitleContainer>
         <RoutineTitle>오늘의 루틴</RoutineTitle>
-        <button onClick={() => navigate('/slot')}>
-          <Plus />
-        </button>
+        <Actions>
+          <button onClick={() => navigate('/slot')}>
+            <Plus />
+          </button>
+          {!routineData && <Notice>슬롯 설정하기</Notice>}
+        </Actions>
       </RoutineTitleContainer>
       {routineData && <RoutineProgress petId={petId} />}
 
@@ -32,6 +39,33 @@ export const Routine = ({ petId }: RoutineProps) => {
 
 const Container = styled.div`
   padding: 12px 20px;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+`;
+
+const Notice = styled.div`
+  position: relative;
+  display: inline-block;
+  padding: 6px 12px;
+  font-size: 14px;
+  background-color: #ffb700;
+  color: white;
+  border-radius: 4px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: -6px;
+    right: 9px;
+    border-width: 0 6px 6px 6px;
+    border-style: solid;
+    border-color: transparent transparent #ffc533 transparent;
+  }
 `;
 
 const RoutineTitleContainer = styled.div`

--- a/src/features/routine/RoutineItem.tsx
+++ b/src/features/routine/RoutineItem.tsx
@@ -8,6 +8,7 @@ import { checkRoutine, uncheckRoutine } from '@/apis/routine';
 import { SLOT_ITEMS } from '@/constants/slot';
 import { RoutineDetailModal } from '@/features/routine/RoutineDetailModal';
 import { useDailyRoutine } from '@/hooks/useDailyRoutine';
+import { useSlot } from '@/hooks/useSlot';
 import type { Routine, SlotId } from '@/types/routine';
 import { formatDate } from '@/utils/calendar';
 
@@ -35,8 +36,10 @@ export const RoutineItem = ({ petId, routines }: RoutineItemProps) => {
     CHECKED: <Check width={24} color="#4D9DE0" />,
   } as const;
 
-  const { data: routineDataFromHook } = useDailyRoutine(petId);
-
+  const { data: slot } = useSlot(petId);
+  const { data: routineDataFromHook } = useDailyRoutine(petId, {
+    enabled: !!slot,
+  });
   const routineList = routines ?? routineDataFromHook;
 
   if (!routineList) {

--- a/src/features/routine/RoutineProgress.tsx
+++ b/src/features/routine/RoutineProgress.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { useDailyRoutine } from '@/hooks/useDailyRoutine';
+import { useSlot } from '@/hooks/useSlot';
 import type { Routine } from '@/types/routine';
 
 interface RoutineProps {
@@ -8,7 +9,10 @@ interface RoutineProps {
 }
 
 export const RoutineProgress = ({ petId }: RoutineProps) => {
-  const { data: routineData, isLoading } = useDailyRoutine(petId);
+  const { data: slot } = useSlot(petId);
+  const { data: routineData, isLoading } = useDailyRoutine(petId, {
+    enabled: !!slot,
+  });
 
   if (isLoading) return <div>로딩중</div>;
 

--- a/src/hooks/useDailyRoutine.ts
+++ b/src/hooks/useDailyRoutine.ts
@@ -4,11 +4,12 @@ import { getDailyRoutine } from '@/apis/routine';
 import type { Routine } from '@/types/routine';
 import { formatDate } from '@/utils/calendar';
 
-export const useDailyRoutine = (petId: number) => {
+export const useDailyRoutine = (petId: number, options?: { enabled?: boolean }) => {
   const today = formatDate(new Date());
 
   return useQuery<Routine[]>({
     queryKey: ['dailyRoutine', petId, today],
     queryFn: () => getDailyRoutine(petId, today),
+    enabled: options?.enabled ?? true,
   });
 };

--- a/src/hooks/useSlot.ts
+++ b/src/hooks/useSlot.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { getSlot } from '@/apis/slot';
+import type { SlotType } from '@/types/slot';
+
+export const useSlot = (petId?: number) => {
+  return useQuery<SlotType | null>({
+    queryKey: ['slot', petId],
+    enabled: !!petId,
+    queryFn: async () => {
+      try {
+        const slot = await getSlot(petId as number);
+        return slot;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    retry: (failureCount, error) => {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+};


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 슬롯을 설정하지 않았을 때, 루틴을 호출하면 에러가 발생함. date를 넣어서 루틴을 호출하는데, 설정된 슬롯이 없으면 매일 루틴이 생성되지 않아 404 에러 발생

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #71 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- `useSlot` 훅 생성해서 슬롯이 설정되어 있지 않으면 오류를 return 하지 않고 null을 return 하도록 함
- `useDailyRoutine`을 호출할 때 슬롯이 있는지 확인하고 슬롯이 없으면 아예 호출하지 않도록 수정
- + 버튼 아래에 슬롯 설정하기 태그 추가해서 사용자들이 슬롯을 설정하도록 유도

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [ ] 홈 화면에서 슬롯이 설정되지 않은 pet은 + 버튼 아래에 슬롯 설정하기가 보이고, 하루 루틴을 호출하지 않음

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
