### PR TITLE
fix: 특이사항 변경 즉시 반영 및 제목 필수화 (KB3-122)

### DIFF
--- a/src/apis/pets.ts
+++ b/src/apis/pets.ts
@@ -69,3 +69,12 @@ export const putFavorite = async (petId: number) => {
     throw error;
   }
 };
+
+// 상세 조회 API
+export const getPetById = async (petId: number): Promise<PetApiResponse> => {
+  const res = await axiosInstance.get<ApiResponse<PetApiResponse>>(`/pets/${petId}`);
+  if (!res.data.success || !res.data.content) {
+    throw new Error(res.data.message || '반려동물 상세 조회 실패');
+  }
+  return res.data.content;
+};

--- a/src/components/common/FormTextarea.tsx
+++ b/src/components/common/FormTextarea.tsx
@@ -11,6 +11,7 @@ interface FormTextareaProps extends BaseFieldProps {
   validationType: ValidationType;
   placeholder?: string;
   onFieldValidChange: (isValid: boolean) => void;
+  optional?: boolean;
 }
 
 export const FormTextarea = ({
@@ -20,6 +21,7 @@ export const FormTextarea = ({
   validationType,
   placeholder,
   onFieldValidChange,
+  optional = false,
 }: FormTextareaProps) => {
   const [isTouched, setIsTouched] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -28,6 +30,16 @@ export const FormTextarea = ({
   const maxLength = MAX_LENGTH[validationType];
 
   useEffect(() => {
+    const trimmed = value?.trim() ?? '';
+
+    // ✅ optional & 빈 값 → 항상 통과(에러 숨김, 부모에 true 전달)
+    if (optional && trimmed === '') {
+      if (errorMessage !== null) setErrorMessage(null);
+      onFieldValidChange(true);
+      return;
+    }
+
+    // ✅ 값이 입력된 경우엔 기존 로직 유지(blur 이후에만 에러 표기/전달)
     if (!isTouched) return;
 
     const { isValid, message } = validators[validationType](value);
@@ -37,6 +49,14 @@ export const FormTextarea = ({
 
   const handleBlur = () => {
     setIsTouched(true);
+
+    // blur 시점에 값이 있으면 즉시 1회 검증(UX 보강)
+    const trimmed = value?.trim() ?? '';
+    if (!(optional && trimmed === '')) {
+      const { isValid, message } = validators[validationType](value);
+      setErrorMessage(!isValid ? message : null);
+      onFieldValidChange(isValid);
+    }
   };
 
   return (

--- a/src/features/home/TodayBar.tsx
+++ b/src/features/home/TodayBar.tsx
@@ -1,15 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
+import { getPetById } from '@/apis/pets';
+import type { RootState } from '@/store/store';
+
 export const TodayBar = () => {
+  const selectedPetId = useSelector((s: RootState) => s.selectedPet.id);
+
+  const { data: pet, isLoading } = useQuery({
+    queryKey: ['pet', selectedPetId],
+    queryFn: () => getPetById(selectedPetId as number),
+    enabled: selectedPetId !== null, // ✅ 선택된 경우만 호출
+    staleTime: 1000 * 60 * 5,
+  });
+
+  // ✅ 'YYYY-MM-DD' 안전 파싱(타임존 이슈 회피)
+  const parseISODate = (iso?: string | null) => {
+    if (!iso) return null;
+    const [y, m, d] = iso.split('-').map(Number);
+    if (!y || !m || !d) return null;
+    return new Date(y, m - 1, d); // 로컬 자정
+  };
+
   const today = new Date();
+  const toYMD = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+  const birth = parseISODate(pet?.birthDate);
+  const diffDays =
+    birth != null
+      ? Math.max(0, Math.floor((toYMD(today).getTime() - toYMD(birth).getTime()) / 86400000))
+      : null;
+
   const formattedDate = `${String(today.getMonth() + 1).padStart(2, '0')}월 ${String(
     today.getDate()
   ).padStart(2, '0')}일`;
 
-  // 기준일: 2023-01-01
-  const startDate = new Date('2023-01-01');
-  const diff = Math.floor((today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
-  const dDay = `D+ ${diff}`;
+  const dDay =
+    selectedPetId === null || isLoading ? 'D —' : diffDays === null ? 'D —' : `D+ ${diffDays}`;
 
   return (
     <Wrapper>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -80,7 +80,7 @@ export const HomePage = () => {
   return (
     <Container>
       <Header>
-        <StyledLogo onClick={() => navigate('/signup/pet')} />
+        <StyledLogo onClick={() => navigate('/')} />
         <Backpack size={24} stroke="#444" />
       </Header>
 


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- 특이사항 변경 시 달력 마킹 즉시 반영: 저장/수정/삭제 후 React Query invalidateQueries로 dailyEntries/monthlyEntries 재조회
- 특이사항 제목 필수화, 본문 선택(optional): NoteModal 초기 유효성 계산 버그 제거 및 FormTextarea(optional) 적용

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #68 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

`NoteModal / FormTextarea`
- 기존 formValidity 패턴 유지, 초기값을 validators 결과로 재계산(제목: 필수, 본문: 빈 값이면 통과)
- FormTextarea에 optional 전달 → 본문 미입력 시 isValid=true

`패널(Monthly / Weekly)`
- 캐시 무효화에 따라 calendarMarks 재계산 → 월/주 뷰 모두 dot 즉시 반영

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [x] 특이사항 생성/수정/삭제 후 월/주 달력에서 note dot 즉시 반영 확인
- [x] 제목 미입력 시 저장 버튼 비활성화 유지, 제목 입력 후 활성화
- [x] 본문 미입력 상태에서 정상 저장, 본문 입력 시 validator(최대 200자·문자 규칙) 동작
- [x] 새로고침 없이 반영(캐시 staleTime과 무관)
- [x] 반려동물 전환(selectedPetId 변경) 시 마킹 일관성 유지

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
- 알림 본문은 optional 여부가 정확하게 정해지지 않은 것 같아서, 기존대로 필수 필드로 유지했습니다.