### PR TITLE
refactor: PetRegisterForm 프레젠테이션화 및 페이지 상태 일원화 (KB3-146)

### DIFF
--- a/src/components/common/TitleHeader.tsx
+++ b/src/components/common/TitleHeader.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { tx } from '@/styles/typography';
+import { theme } from '@/styles/theme';
 
 interface HeaderProps {
   title: string;
@@ -56,8 +58,8 @@ const HeaderBar = styled.header`
 const Title = styled.div`
   flex: 1;
   text-align: center;
-  font-size: 18px;
-  font-weight: 600;
+  ${tx.title('semi18')};
+  color: ${({ theme }) => theme.color.gray[700]};
 `;
 
 const SlotBox = styled.div`

--- a/src/constants/alarm.ts
+++ b/src/constants/alarm.ts
@@ -1,0 +1,5 @@
+export const ALARM_TITLE_VALIDATE_MAX = 20;
+export const ALARM_CONTENT_VALIDATE_MAX = 200;
+
+export const ALARM_TITLE_INPUT_MAX = 30;
+export const ALARM_CONTENT_INPUT_MAX = 250;

--- a/src/constants/note.ts
+++ b/src/constants/note.ts
@@ -1,0 +1,5 @@
+export const NOTE_TITLE_VALIDATE_MAX = 20;
+export const NOTE_CONTENT_VALIDATE_MAX = 200;
+
+export const NOTE_TITLE_INPUT_MAX = 30;
+export const NOTE_CONTENT_INPUT_MAX = 250;

--- a/src/constants/pet.ts
+++ b/src/constants/pet.ts
@@ -1,0 +1,2 @@
+export const PET_NAME_INPUT_MAX = 30; // 입력 허용 한도
+export const PET_NAME_VALIDATE_MAX = 20; // 검증 한도

--- a/src/constants/user.ts
+++ b/src/constants/user.ts
@@ -1,0 +1,2 @@
+export const USER_NICKNAME_VALIDATE_MAX = 10;
+export const USER_NICKNAME_INPUT_MAX = 20;

--- a/src/hooks/useImeMaxLength.ts
+++ b/src/hooks/useImeMaxLength.ts
@@ -1,0 +1,34 @@
+type Params = {
+  setValue: (v: string) => void;
+  max: number;
+};
+// 공용: input | textarea 모두 지원
+type Elem = HTMLInputElement | HTMLTextAreaElement;
+
+/**
+ * IME(한글 등 조합형 입력) 환경에서 조합 중 네이티브 maxLength가 일시 무시되는 문제를
+ * onChange 즉시 slice + onCompositionEnd 보정 + onPaste 보정으로 해결.
+ */
+export function useImeMaxLength({ setValue, max }: Params) {
+  const imeOnChange: React.ChangeEventHandler<Elem> = e => {
+    const raw = e.target.value;
+    setValue(raw.length > max ? raw.slice(0, max) : raw);
+  };
+
+  const imeOnCompositionEnd: React.CompositionEventHandler<Elem> = e => {
+    const v = e.currentTarget.value;
+    if (v.length > max) setValue(v.slice(0, max));
+  };
+
+  const imeOnPaste: React.ClipboardEventHandler<Elem> = e => {
+    const paste = e.clipboardData?.getData('text') ?? '';
+    const input = e.currentTarget;
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? start;
+    const next = (input.value.slice(0, start) + paste + input.value.slice(end)).slice(0, max);
+    e.preventDefault();
+    setValue(next);
+  };
+
+  return { imeOnChange, imeOnCompositionEnd, imeOnPaste };
+}

--- a/src/hooks/usePetForm.ts
+++ b/src/hooks/usePetForm.ts
@@ -1,0 +1,27 @@
+import { useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import type { PetForm } from '@/types/form';
+import { validators } from '@/utils/validators';
+
+type Errors = Partial<Record<keyof PetForm, string | null>>;
+
+export const usePetForm = (form: PetForm, setForm: Dispatch<SetStateAction<PetForm>>) => {
+  const [touched, setTouched] = useState<Partial<Record<keyof PetForm, boolean>>>({});
+
+  const raw = useMemo(() => {
+    const res = validators.petName(form.name);
+    return { name: res.isValid ? null : res.message } as Errors;
+  }, [form.name]);
+
+  const errors: Errors = { name: touched.name ? raw.name : null };
+  const isValid = !raw.name;
+
+  const setField = <K extends keyof PetForm>(k: K, v: PetForm[K]) => {
+    setForm(prev => ({ ...prev, [k]: v }));
+  };
+
+  const onBlurField = (field: keyof PetForm) => {
+    setTouched(prev => ({ ...prev, [field]: true }));
+  };
+
+  return { errors, isValid, setField, onBlurField };
+};

--- a/src/pages/SignupPetRegisterPage.tsx
+++ b/src/pages/SignupPetRegisterPage.tsx
@@ -10,6 +10,8 @@ import { setSelectedPet, setSelectedPetId } from '@/store/petSlice';
 import { tx } from '@/styles/typography';
 import type { PetForm } from '@/types/form';
 import { usePetForm } from '@/hooks/usePetForm';
+import { Button } from '@/ds/Button';
+import { TitleHeader } from '@/components/common/TitleHeader';
 
 export const SignupPetRegisterPage = () => {
   const [form, setForm] = useState<PetForm>({
@@ -41,14 +43,16 @@ export const SignupPetRegisterPage = () => {
 
   return (
     <Container>
-      <Title>반려동물 정보 입력</Title>
+      <TitleHeader title="반려동물 정보 입력" />
 
       <PetRegisterForm form={form} errors={errors} onChange={setField} onBlurField={onBlurField} />
 
       {error && <ErrorMessage>{error}</ErrorMessage>}
-      <NextButton onClick={handleNextClick} disabled={!isValid || loading}>
-        {loading ? '등록 중...' : '다음'}
-      </NextButton>
+      <Footer>
+        <Button size="lg" fullWidth disabled={!isValid || loading} onClick={handleNextClick}>
+          {loading ? '등록 중...' : '다음'}
+        </Button>
+      </Footer>
     </Container>
   );
 };
@@ -60,13 +64,6 @@ const Container = styled.div`
   padding: 0 20px;
 `;
 
-const Title = styled.h2`
-  padding: 18px 0;
-  text-align: center;
-  color: ${({ theme }) => theme.color.gray[700]};
-  ${tx.title('semi18')};
-`;
-
 const ErrorMessage = styled.p`
   margin: 8px 0;
   text-align: center;
@@ -74,19 +71,6 @@ const ErrorMessage = styled.p`
   ${tx.body('reg14')};
 `;
 
-const NextButton = styled.button`
+const Footer = styled.div`
   margin-bottom: 24px;
-  padding: 16px 0;
-  border-radius: 12px;
-  ${tx.title('semi18')};
-
-  background: ${({ theme }) => theme.color.main[500]};
-  color: ${({ theme }) => theme.color.gray[700]};
-
-  &:disabled {
-    background: ${({ theme }) => theme.color.gray[100]};
-    color: ${({ theme }) => theme.color.gray[400]};
-    border: 1px solid ${({ theme }) => theme.color.gray[300]};
-    cursor: not-allowed;
-  }
 `;

--- a/src/pages/SignupPetRegisterPage.tsx
+++ b/src/pages/SignupPetRegisterPage.tsx
@@ -9,6 +9,7 @@ import { useRegisterPet } from '@/hooks/useRegisterPet';
 import { setSelectedPet, setSelectedPetId } from '@/store/petSlice';
 import { tx } from '@/styles/typography';
 import type { PetForm } from '@/types/form';
+import { usePetForm } from '@/hooks/usePetForm';
 
 export const SignupPetRegisterPage = () => {
   const [form, setForm] = useState<PetForm>({
@@ -17,14 +18,15 @@ export const SignupPetRegisterPage = () => {
     gender: '남아',
     birthDate: new Date(),
   });
-  const [isPetFormValid, setIsPetFormValid] = useState(false);
+
+  const { errors, isValid, setField, onBlurField } = usePetForm(form, setForm);
 
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { register, loading, error } = useRegisterPet();
 
   const handleNextClick = async () => {
-    if (!isPetFormValid || loading) return;
+    if (!isValid || loading) return;
 
     const petInfo = await register(form); // ✅ id 포함 결과
 
@@ -41,11 +43,10 @@ export const SignupPetRegisterPage = () => {
     <Container>
       <Title>반려동물 정보 입력</Title>
 
-      <PetRegisterForm form={form} setForm={setForm} onFormValidChange={setIsPetFormValid} />
+      <PetRegisterForm form={form} errors={errors} onChange={setField} onBlurField={onBlurField} />
 
       {error && <ErrorMessage>{error}</ErrorMessage>}
-
-      <NextButton onClick={handleNextClick} disabled={!isPetFormValid || loading}>
+      <NextButton onClick={handleNextClick} disabled={!isValid || loading}>
         {loading ? '등록 중...' : '다음'}
       </NextButton>
     </Container>

--- a/src/types/pet.ts
+++ b/src/types/pet.ts
@@ -1,0 +1,31 @@
+export const PET_SPECIES_KO = ['강아지', '고양이', '햄스터', '조류', '파충류', '어류'] as const;
+export type PetSpeciesKo = (typeof PET_SPECIES_KO)[number];
+
+export const PET_GENDERS_KO = ['남아', '여아', '중성'] as const;
+export type PetGenderKo = (typeof PET_GENDERS_KO)[number];
+
+export interface PetBase {
+  name: string;
+  species: PetSpeciesKo;
+  gender: PetGenderKo;
+  birthDate: Date; // 프론트는 Date 객체 사용
+  isFavorite: boolean;
+}
+
+// 서버 전송용 Request DTO
+export interface PetRequestDto extends Omit<PetBase, 'isFavorite'> {
+  memberId: number;
+}
+
+// 서버 응답용 Response DTO
+export interface PetResponseDto extends PetBase {
+  id: number;
+}
+
+// UI 전용 Form 모델 (isFavorite, id 없음)
+export interface PetForm extends Omit<PetBase, 'isFavorite'> {}
+
+// 전역/Redux 등에 저장되는 UI 모델
+export interface PetInfo extends PetBase {
+  id: number;
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -6,6 +6,7 @@ interface ValidatorResult {
   message: string;
 }
 
+// @deprecated
 // ✅ 필드별 최대 길이 상수
 export const MAX_LENGTH = {
   petName: 20,
@@ -14,8 +15,8 @@ export const MAX_LENGTH = {
   nickname: 10,
 } as const;
 
-// ✅ 정규식 (예: 특수 문자 허용 포함)
-export const VALID_CHAR_REGEX = /^[\w가-힣\s!@#%^&*()[\]{}\-_=+~;:'",.<>/?\\|`·★♡♥]+$/;
+// ✅ 정규식
+export const VALID_CHAR_REGEX = /^[가-힣a-zA-Z]+$/;
 
 // ✅ 공통 메시지 템플릿
 export const VALIDATION_MESSAGES = {


### PR DESCRIPTION
<!--
📌 PR 제목은 다음과 같은 형식으로 작성해주세요:

feat: 리뷰 정렬 기능 추가 (KB3-10)

Reviewers, Assignees, Labels 설정해주세요.
-->

### ✅ 작업 내용 요약

<!-- 이 PR에서 구현하거나 수정한 핵심 내용을 한 줄로 요약해주세요 -->

- PetRegisterForm 프레젠테이션화 및 페이지 단 상태 일원화
- DS 컴포넌트(Field, InputBase, Button) 도입

### 🧩 관련 이슈

<!-- 이 PR이 머지되면 자동으로 닫을 이슈를 명시하세요 -->

- resolve #94 

### 🔍 변경 상세 내용

<!-- 어떤 점이 변경되었는지 구체적으로 작성하세요 -->

- PetRegisterForm에서 비즈니스 로직 제거 → UI 전담 컴포넌트로 전환
- 유효성 검사 및 touched 관리 로직을 usePetForm 훅으로 이동
- SignupPetRegisterPage에서 단일 상태 관리하도록 구조 변경
- 기존 Next 버튼 제거 후 DS Button 컴포넌트로 교체
- 반려동물 정보 입력 시 IME 입력 보정 훅(useImeMaxLength) 적용

### 🧪 테스트 결과

<!-- 테스트 여부를 체크박스로 표시하고 결과 요약 -->

- [ ] 반려동물 이름 입력 시 최대 30자까지 작성 가능, 21자 이상일 경우 에러 메시지 표시
- [ ] 필수 필드 누락 시 유효성 검사 에러 발생 확인
- [ ] 등록 성공 시 전역 상태(petSlice) 반영 및 /slot?flow=signup 이동 확인
- [ ] 등록 실패 시 에러 메시지 노출 확인

### 📝 기타 참고 사항

<!-- 문서, 디자인 링크 등 참고할 자료가 있다면 작성하세요 -->
RFC에서 제안드린 것처럼, types/pet.ts에 도메인별 타입을 묶어 관리하는 방식으로 점진적으로 수정·적용해 나가면 어떨까 합니다!